### PR TITLE
Tags can be found in the properties of a page

### DIFF
--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -112,8 +112,8 @@ class ListPagesToolHandler(ToolHandler):
                 
                 # Get page information
                 name = page.get('originalName') or page.get('name', '<unknown>')
-                tags = page.get('tags', [])
                 properties = page.get('properties', {})
+                tags = properties.get('tags', [])
                 
                 # Build page info string
                 info_parts = [f"- {name}"]


### PR DESCRIPTION
This fixes an exception like:
```
expected str instance, dict found
```