### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-logseq"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP server to work with LogSeq via the local HTTP server"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Version bump for PyPI release. 1.6.0 was already published from an earlier commit and is missing the read-only MCP server refactor and bug fixes.

### Fixes included in 1.6.1 (not in 1.6.0 on PyPI)
- Read-only MCP server — all DB writes delegated to `logseq-sync`
- Graph-path guard prevents data wipe when vault is inaccessible
- State migration from absolute to relative path keys
- Inter-process file lock for concurrent sync protection
- LanceDB version mismatch detection in `open_readonly()`