### PR TITLE
feat: resolve UUID page references in DB mode

### DIFF
--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -975,6 +975,44 @@ class LogSeq:
             logger.error(f"Error getting block '{block_uuid}': {str(e)}")
             raise
 
+    def resolve_page_uuids(self, uuids: list[str]) -> dict[str, str]:
+        """Resolve a list of page UUIDs to their human-readable names.
+
+        Batch-resolves by calling logseq.Editor.getPage once per unique UUID.
+        Results are returned as a dict mapping UUID -> page name.
+        UUIDs that cannot be resolved are silently omitted.
+
+        Args:
+            uuids: List of page UUID strings to resolve.
+
+        Returns:
+            Dict mapping UUID string to page name string.
+        """
+        url = self.get_base_url()
+        resolved = {}
+
+        for uuid in set(uuids):
+            try:
+                response = requests.post(
+                    url,
+                    headers=self._get_headers(),
+                    json={"method": "logseq.Editor.getPage", "args": [uuid]},
+                    verify=self.verify_ssl,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                page = response.json()
+
+                if page and isinstance(page, dict):
+                    name = page.get("originalName") or page.get("name")
+                    if name:
+                        resolved[uuid] = name
+            except Exception as e:
+                logger.warning(f"Could not resolve page UUID '{uuid}': {e}")
+
+        logger.info(f"Resolved {len(resolved)}/{len(set(uuids))} page UUIDs")
+        return resolved
+
     def delete_block(self, block_uuid: str) -> Any:
         """Delete a LogSeq block by UUID."""
         url = self.get_base_url()

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -39,6 +40,34 @@ def _make_api() -> logseq.LogSeq:
         port=_api_port,
         verify_ssl=_api_verify_ssl,
     )
+
+
+# Regex matching [[uuid]] references in DB-mode block content
+_UUID_REF_PATTERN = re.compile(r"\[\[([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]\]")
+
+
+def _collect_block_uuids(blocks: list[dict]) -> set[str]:
+    """Recursively collect all page-reference UUIDs from block content strings."""
+    uuids: set[str] = set()
+    for block in blocks:
+        content = block.get("content", "")
+        uuids.update(_UUID_REF_PATTERN.findall(content))
+        children = block.get("children", [])
+        if children:
+            uuids.update(_collect_block_uuids(children))
+    return uuids
+
+
+def _resolve_block_refs(content: str, uuid_map: dict[str, str]) -> str:
+    """Replace [[uuid]] patterns in content with [[Page Name]] using a pre-resolved map."""
+    def _replace(match: re.Match) -> str:
+        uuid = match.group(1)
+        name = uuid_map.get(uuid)
+        if name:
+            return f"[[{name}]]"
+        return match.group(0)  # Keep original if not resolved
+
+    return _UUID_REF_PATTERN.sub(_replace, content)
 
 
 class ToolHandler:
@@ -233,6 +262,7 @@ class GetPageContentToolHandler(ToolHandler):
     def _format_block_tree(
         block: dict, indent_level: int = 0, max_depth: int = -1,
         db_properties: dict[str, dict[str, str]] | None = None,
+        uuid_map: dict[str, str] | None = None,
     ) -> list[str]:
         """
         Recursively format a block and its children with proper indentation.
@@ -241,6 +271,8 @@ class GetPageContentToolHandler(ToolHandler):
             block: Block dict with 'content', 'children', and optional 'properties', 'marker'
             indent_level: Current indentation level (0-based)
             max_depth: Maximum depth to recurse (-1 for unlimited)
+            db_properties: DB-mode class properties keyed by block UUID
+            uuid_map: Mapping of page UUIDs to page names for resolving [[uuid]] refs
 
         Returns:
             List of formatted lines for this block and its children
@@ -249,6 +281,10 @@ class GetPageContentToolHandler(ToolHandler):
 
         # Get block content
         content = block.get("content", "").strip()
+
+        # Resolve [[uuid]] references to [[Page Name]] if a map is provided
+        if uuid_map and content:
+            content = _resolve_block_refs(content, uuid_map)
         if not content:
             return lines
 
@@ -284,7 +320,7 @@ class GetPageContentToolHandler(ToolHandler):
         if children and (max_depth == -1 or indent_level < max_depth):
             for child in children:
                 child_lines = GetPageContentToolHandler._format_block_tree(
-                    child, indent_level + 1, max_depth, db_properties
+                    child, indent_level + 1, max_depth, db_properties, uuid_map
                 )
                 lines.extend(child_lines)
 
@@ -312,6 +348,11 @@ class GetPageContentToolHandler(ToolHandler):
                         "description": "Maximum nesting depth to display (default: -1 for unlimited)",
                         "default": -1,
                     },
+                    "resolve_refs": {
+                        "type": "boolean",
+                        "description": "Resolve [[uuid]] page references to [[Page Name]] in DB mode (default: true)",
+                        "default": True,
+                    },
                 },
                 "required": ["page_name"],
             },
@@ -337,6 +378,18 @@ class GetPageContentToolHandler(ToolHandler):
 
             # Handle JSON format request
             if args.get("format") == "json":
+                # In DB mode with resolve_refs, enrich JSON with resolved page names
+                if _db_mode and args.get("resolve_refs", True):
+                    blocks = result.get("blocks", [])
+                    page_uuids = _collect_block_uuids(blocks)
+                    if page_uuids:
+                        try:
+                            uuid_map = api.resolve_page_uuids(list(page_uuids))
+                            if uuid_map:
+                                result = dict(result)
+                                result["resolved_refs"] = uuid_map
+                        except Exception as e:
+                            logger.warning(f"Could not resolve refs for JSON: {e}")
                 return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
             # Format as readable text
@@ -347,6 +400,7 @@ class GetPageContentToolHandler(ToolHandler):
 
             # Fetch DB-mode class properties (only when LOGSEQ_DB_MODE is enabled)
             db_properties = {}
+            uuid_map: dict[str, str] = {}
             if _db_mode:
                 try:
                     db_properties = api.get_blocks_db_properties(blocks)
@@ -354,13 +408,23 @@ class GetPageContentToolHandler(ToolHandler):
                 except Exception as e:
                     logger.warning(f"Could not fetch DB-mode properties: {e}")
 
+                # Resolve [[uuid]] page references to readable names
+                resolve_refs = args.get("resolve_refs", True)
+                if resolve_refs:
+                    try:
+                        page_uuids = _collect_block_uuids(blocks)
+                        if page_uuids:
+                            uuid_map = api.resolve_page_uuids(list(page_uuids))
+                    except Exception as e:
+                        logger.warning(f"Could not resolve page refs: {e}")
+
             # Blocks content - use recursive formatter
             max_depth = args.get("max_depth", -1)
             if blocks:
                 for block in blocks:
                     if isinstance(block, dict):
                         block_lines = self._format_block_tree(
-                            block, 0, max_depth, db_properties
+                            block, 0, max_depth, db_properties, uuid_map
                         )
                         content_parts.extend(block_lines)
                     elif isinstance(block, str) and block.strip():

--- a/tests/unit/test_db_properties.py
+++ b/tests/unit/test_db_properties.py
@@ -6,7 +6,12 @@ import responses
 from unittest.mock import patch, Mock
 
 from mcp_logseq.logseq import LogSeq
-from mcp_logseq.tools import GetPageContentToolHandler
+from mcp_logseq.tools import (
+    GetPageContentToolHandler,
+    _collect_block_uuids,
+    _resolve_block_refs,
+    _UUID_REF_PATTERN,
+)
 
 
 @pytest.fixture
@@ -397,3 +402,335 @@ class TestFeatureFlagIntegration:
 
         assert "LOGSEQ_DB_MODE=true" in result[0].text
         assert len(responses.calls) == 0  # No API calls made
+
+
+class TestUuidRefResolution:
+    """Tests for resolving [[uuid]] page references to [[Page Name]]."""
+
+    def test_uuid_ref_pattern_matches(self):
+        """Regex matches valid UUID references in double brackets."""
+        content = "Link to [[69133208-abcd-4ef0-1234-567890abcdef]] here"
+        matches = _UUID_REF_PATTERN.findall(content)
+        assert matches == ["69133208-abcd-4ef0-1234-567890abcdef"]
+
+    def test_uuid_ref_pattern_multiple(self):
+        """Regex matches multiple UUID references."""
+        content = "See [[aaaa1111-2222-3333-4444-555566667777]] and [[bbbb1111-2222-3333-4444-555566667777]]"
+        matches = _UUID_REF_PATTERN.findall(content)
+        assert len(matches) == 2
+
+    def test_uuid_ref_pattern_ignores_non_uuids(self):
+        """Regex does not match non-UUID bracket content."""
+        content = "Link to [[My Page]] and [[Another Page]]"
+        matches = _UUID_REF_PATTERN.findall(content)
+        assert matches == []
+
+    def test_uuid_ref_pattern_ignores_bare_uuids(self):
+        """Regex does not match UUIDs outside of brackets."""
+        content = "UUID is 69133208-abcd-4ef0-1234-567890abcdef"
+        matches = _UUID_REF_PATTERN.findall(content)
+        assert matches == []
+
+    def test_collect_block_uuids_flat(self):
+        """Collects UUIDs from flat block list."""
+        blocks = [
+            {"content": "See [[aaaa1111-2222-3333-4444-555566667777]]", "children": []},
+            {"content": "And [[bbbb1111-2222-3333-4444-555566667777]]", "children": []},
+        ]
+        uuids = _collect_block_uuids(blocks)
+        assert uuids == {"aaaa1111-2222-3333-4444-555566667777", "bbbb1111-2222-3333-4444-555566667777"}
+
+    def test_collect_block_uuids_nested(self):
+        """Collects UUIDs from nested children."""
+        blocks = [
+            {
+                "content": "Parent [[aaaa1111-2222-3333-4444-555566667777]]",
+                "children": [
+                    {"content": "Child [[bbbb1111-2222-3333-4444-555566667777]]", "children": []},
+                ],
+            },
+        ]
+        uuids = _collect_block_uuids(blocks)
+        assert len(uuids) == 2
+
+    def test_collect_block_uuids_deduplicates(self):
+        """Same UUID appearing twice is collected once."""
+        blocks = [
+            {"content": "A [[aaaa1111-2222-3333-4444-555566667777]]", "children": []},
+            {"content": "B [[aaaa1111-2222-3333-4444-555566667777]]", "children": []},
+        ]
+        uuids = _collect_block_uuids(blocks)
+        assert len(uuids) == 1
+
+    def test_resolve_block_refs_replaces(self):
+        """Resolved UUIDs are replaced with page names."""
+        content = "See [[aaaa1111-2222-3333-4444-555566667777]] for details"
+        uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "Administratie"}
+        result = _resolve_block_refs(content, uuid_map)
+        assert result == "See [[Administratie]] for details"
+
+    def test_resolve_block_refs_keeps_unresolved(self):
+        """Unresolved UUIDs are left as-is."""
+        content = "See [[aaaa1111-2222-3333-4444-555566667777]]"
+        uuid_map = {}
+        result = _resolve_block_refs(content, uuid_map)
+        assert result == content
+
+    def test_resolve_block_refs_mixed(self):
+        """Mix of resolved and unresolved refs."""
+        content = "A [[aaaa1111-2222-3333-4444-555566667777]] B [[bbbb1111-2222-3333-4444-555566667777]]"
+        uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "Page A"}
+        result = _resolve_block_refs(content, uuid_map)
+        assert "[[Page A]]" in result
+        assert "[[bbbb1111-2222-3333-4444-555566667777]]" in result
+
+    def test_format_block_tree_resolves_refs(self):
+        """_format_block_tree replaces UUID refs when uuid_map is provided."""
+        block = {
+            "content": "Link to [[aaaa1111-2222-3333-4444-555566667777]]",
+            "uuid": "block-1",
+            "properties": {},
+            "children": [],
+        }
+        uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "My Page"}
+
+        with patch("mcp_logseq.tools._db_mode", True):
+            lines = GetPageContentToolHandler._format_block_tree(
+                block, 0, -1, None, uuid_map
+            )
+
+        assert "[[My Page]]" in lines[0]
+        assert "aaaa1111" not in lines[0]
+
+    def test_format_block_tree_no_uuid_map(self):
+        """_format_block_tree leaves UUID refs when no map is provided."""
+        block = {
+            "content": "Link to [[aaaa1111-2222-3333-4444-555566667777]]",
+            "uuid": "block-1",
+            "properties": {},
+            "children": [],
+        }
+
+        with patch("mcp_logseq.tools._db_mode", True):
+            lines = GetPageContentToolHandler._format_block_tree(
+                block, 0, -1, None, None
+            )
+
+        assert "aaaa1111-2222-3333-4444-555566667777" in lines[0]
+
+    def test_format_block_tree_resolves_in_children(self):
+        """UUID refs in child blocks are also resolved."""
+        block = {
+            "content": "Parent",
+            "uuid": "parent-1",
+            "properties": {},
+            "children": [
+                {
+                    "content": "Child links to [[aaaa1111-2222-3333-4444-555566667777]]",
+                    "uuid": "child-1",
+                    "properties": {},
+                    "children": [],
+                }
+            ],
+        }
+        uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "Resolved Page"}
+
+        with patch("mcp_logseq.tools._db_mode", True):
+            lines = GetPageContentToolHandler._format_block_tree(
+                block, 0, -1, None, uuid_map
+            )
+
+        child_line = [l for l in lines if "Child" in l][0]
+        assert "[[Resolved Page]]" in child_line
+
+
+class TestResolvePageUuids:
+    """Tests for the LogSeq.resolve_page_uuids API method."""
+
+    @responses.activate
+    def test_resolve_success(self):
+        """Successfully resolves page UUIDs to names."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "administratie", "originalName": "Administratie", "uuid": "uuid-1"},
+            status=200)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["uuid-1"])
+
+        assert result == {"uuid-1": "Administratie"}
+        body = json.loads(responses.calls[0].request.body)
+        assert body["method"] == "logseq.Editor.getPage"
+        assert body["args"] == ["uuid-1"]
+
+    @responses.activate
+    def test_resolve_prefers_originalName(self):
+        """Uses originalName over name when available."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "my page", "originalName": "My Page", "uuid": "uuid-1"},
+            status=200)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["uuid-1"])
+
+        assert result["uuid-1"] == "My Page"
+
+    @responses.activate
+    def test_resolve_not_found(self):
+        """UUIDs that don't resolve to a page are omitted."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url, body="null",
+            content_type="application/json", status=200)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["bad-uuid"])
+
+        assert result == {}
+
+    @responses.activate
+    def test_resolve_deduplicates(self):
+        """Duplicate UUIDs result in a single API call."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "page", "originalName": "Page", "uuid": "uuid-1"},
+            status=200)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["uuid-1", "uuid-1", "uuid-1"])
+
+        assert len(responses.calls) == 1
+        assert result == {"uuid-1": "Page"}
+
+    @responses.activate
+    def test_resolve_api_error_skips(self):
+        """API errors for individual UUIDs are silently skipped."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url, json={"error": "fail"}, status=500)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["uuid-1"])
+
+        assert result == {}
+
+    @responses.activate
+    def test_resolve_multiple_uuids(self):
+        """Resolves multiple distinct UUIDs."""
+        api_url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "page a", "originalName": "Page A", "uuid": "uuid-a"},
+            status=200)
+        responses.add(responses.POST, api_url,
+            json={"id": 2, "name": "page b", "originalName": "Page B", "uuid": "uuid-b"},
+            status=200)
+
+        client = LogSeq(api_key="test", host="127.0.0.1", port=12315)
+        result = client.resolve_page_uuids(["uuid-a", "uuid-b"])
+
+        assert len(result) == 2
+        assert "Page A" in result.values()
+        assert "Page B" in result.values()
+
+
+class TestGetPageContentResolveRefs:
+    """Tests for resolve_refs integration in get_page_content tool."""
+
+    @responses.activate
+    def test_resolve_refs_enabled_in_db_mode(self):
+        """UUID refs are resolved when LOGSEQ_DB_MODE is on and resolve_refs is true."""
+        api_url = "http://localhost:12315/api"
+        # getPage
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "Test", "originalName": "Test", "uuid": "page-uuid"},
+            status=200)
+        # getPageBlocksTree
+        responses.add(responses.POST, api_url,
+            json=[{
+                "id": 1, "uuid": "b1",
+                "content": "See [[aaaa1111-2222-3333-4444-555566667777]]",
+                "properties": {}, "children": [],
+            }],
+            status=200)
+        # resolve_page_uuids -> getPage for the UUID
+        responses.add(responses.POST, api_url,
+            json={"id": 2, "name": "target", "originalName": "Target Page", "uuid": "aaaa1111-2222-3333-4444-555566667777"},
+            status=200)
+
+        handler = GetPageContentToolHandler()
+        with patch("mcp_logseq.tools._db_mode", True):
+            result = handler.run_tool({"page_name": "Test"})
+
+        assert "[[Target Page]]" in result[0].text
+        assert "aaaa1111" not in result[0].text
+
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_resolve_refs_disabled(self, mock_logseq_class):
+        """UUID refs are NOT resolved when resolve_refs=false."""
+        mock_api = Mock()
+        mock_api.get_page_content.return_value = {
+            "page": {"name": "Test", "originalName": "Test", "uuid": "page-uuid"},
+            "blocks": [{
+                "id": 1, "uuid": "b1",
+                "content": "See [[aaaa1111-2222-3333-4444-555566667777]]",
+                "properties": {}, "children": [],
+            }],
+        }
+        mock_api.get_blocks_db_properties.return_value = {}
+        mock_logseq_class.return_value = mock_api
+
+        handler = GetPageContentToolHandler()
+        with patch("mcp_logseq.tools._db_mode", True):
+            result = handler.run_tool({"page_name": "Test", "resolve_refs": False})
+
+        assert "aaaa1111-2222-3333-4444-555566667777" in result[0].text
+        # resolve_page_uuids should NOT be called
+        mock_api.resolve_page_uuids.assert_not_called()
+
+    @responses.activate
+    def test_resolve_refs_skipped_in_markdown_mode(self):
+        """No UUID resolution in markdown mode."""
+        api_url = "http://localhost:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "Test", "originalName": "Test", "uuid": "page-uuid"},
+            status=200)
+        responses.add(responses.POST, api_url,
+            json=[{
+                "id": 1, "uuid": "b1",
+                "content": "See [[My Page]]",
+                "properties": {}, "children": [],
+            }],
+            status=200)
+
+        handler = GetPageContentToolHandler()
+        with patch("mcp_logseq.tools._db_mode", False):
+            result = handler.run_tool({"page_name": "Test"})
+
+        assert "[[My Page]]" in result[0].text
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_json_format_includes_resolved_refs(self):
+        """JSON format includes resolved_refs mapping in DB mode."""
+        api_url = "http://localhost:12315/api"
+        responses.add(responses.POST, api_url,
+            json={"id": 1, "name": "Test", "originalName": "Test", "uuid": "page-uuid"},
+            status=200)
+        responses.add(responses.POST, api_url,
+            json=[{
+                "id": 1, "uuid": "b1",
+                "content": "See [[aaaa1111-2222-3333-4444-555566667777]]",
+                "properties": {}, "children": [],
+            }],
+            status=200)
+        responses.add(responses.POST, api_url,
+            json={"id": 2, "name": "target", "originalName": "Target", "uuid": "aaaa1111-2222-3333-4444-555566667777"},
+            status=200)
+
+        handler = GetPageContentToolHandler()
+        with patch("mcp_logseq.tools._db_mode", True):
+            result = handler.run_tool({"page_name": "Test", "format": "json"})
+
+        parsed = json.loads(result[0].text)
+        assert "resolved_refs" in parsed
+        assert parsed["resolved_refs"]["aaaa1111-2222-3333-4444-555566667777"] == "Target"


### PR DESCRIPTION
## Summary

Fixes #21 — `get_page_content` in DB mode returns `[[uuid]]` instead of `[[Page Name]]` for page references, making output unreadable.

This PR adds automatic UUID-to-name resolution:

- **Text format**: `[[69133208-...]]` → `[[Administratie]]` (default behavior)
- **JSON format**: adds a `resolved_refs` mapping (`uuid → name`) alongside raw content, so agents can read names but use UUIDs for write operations
- **`resolve_refs` parameter**: opt-out with `resolve_refs=false` when raw UUIDs are needed

## How it works

1. After fetching blocks, a regex (`\[\[([0-9a-f-]{36})\]\]`) extracts all UUID references
2. Unique UUIDs are batch-resolved via `logseq.Editor.getPage`, preferring `originalName` over `name`
3. A pre-built map is passed through `_format_block_tree` to replace refs during formatting

## Design decisions

- **Gated behind `LOGSEQ_DB_MODE`** — markdown-mode users see zero change in behavior or performance
- **Batch with dedup** — duplicate UUIDs across blocks result in a single API call per unique UUID
- **Graceful degradation** — if a UUID can't be resolved (deleted page, API error), it's left as-is
- **Resolution happens in `run_tool`**, not `_format_block_tree` — collect all UUIDs first, resolve once, then pass the map down

## Test plan

- [x] 23 new tests covering:
  - UUID regex pattern matching (valid, invalid, bare UUIDs)
  - `_collect_block_uuids` (flat, nested, dedup)
  - `_resolve_block_refs` (replace, keep unresolved, mixed)
  - `_format_block_tree` with uuid_map (root, children, without map)
  - `resolve_page_uuids` API method (success, originalName preference, not found, dedup, API error, multiple)
  - Integration: resolve_refs enabled, disabled, markdown-mode skip, JSON format
- [x] All 323 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)