### PR TITLE
chore: bump version to 1.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-logseq"
-version = "1.6.1"
+version = "1.6.2"
 description = "MCP server to work with LogSeq via the local HTTP server"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version to 1.6.2 for release

## Changes since v1.6.1
- feat: resolve UUID page references in DB mode (#32)
- fix: Windows compatibility — replace fcntl with portalocker (#38)
- feat: add get_block tool (#31)
- fix: search broken in DB mode (#33)
- chore: add MIT license and fix newlines in markdown tables (#36)