### PR TITLE
feat: add exclude_tags to hide private pages from all MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,32 @@ def hello():
 - **`LOGSEQ_API_TOKEN`** (required): Your LogSeq API token
 - **`LOGSEQ_API_URL`** (optional): Server URL (default: `http://localhost:12315`)
 - **`LOGSEQ_DB_MODE`** (optional): Set to `true` to enable DB-mode property support. Only for Logseq DB-mode graphs (beta). Markdown/file-based graph users should leave this unset.
+- **`LOGSEQ_EXCLUDE_TAGS`** (optional): Comma-separated tags — pages with these tags are hidden from all tools. See [Privacy & Access Control](#-privacy--access-control) below.
+
+### Privacy & Access Control
+
+Pages tagged with excluded tags are completely hidden from AI — they won't appear in listings, searches, or queries, and attempting to read them directly returns an access-denied error.
+
+**Quick setup via env var:**
+```bash
+LOGSEQ_EXCLUDE_TAGS=private,secret
+```
+
+**Via config file** (also used for [vector search](VECTOR_SEARCH.md)):
+```json
+{
+  "logseq_graph_path": "/path/to/your/logseq/pages",
+  "exclude_tags": ["private", "secret"]
+}
+```
+Point to it with `LOGSEQ_CONFIG_FILE=/path/to/config.json`.
+
+In your Logseq pages, tag any page you want to protect:
+```
+tags:: private
+```
+
+The exclusion applies to all tools: `list_pages`, `get_page_content`, `search`, `query`, and the optional vector search. If you also use vector search, `exclude_tags` at the root is automatically merged into the vector index exclusion list — private pages are never embedded.
 
 ### Alternative Setup Methods
 

--- a/VECTOR_SEARCH.md
+++ b/VECTOR_SEARCH.md
@@ -66,6 +66,7 @@ mkdir -p ~/.logseq-vector
 ```json
 {
   "logseq_graph_path": "~/Library/Mobile Documents/iCloud~com~logseq~logseq/Documents",
+  "exclude_tags": ["private"],
   "vector": {
     "enabled": true,
     "db_path": "~/.logseq-vector/db",
@@ -75,7 +76,7 @@ mkdir -p ~/.logseq-vector
       "base_url": "http://localhost:11434"
     },
     "include_journals": true,
-    "exclude_tags": ["private"],
+    "exclude_tags": ["no-index"],
     "min_chunk_length": 50
   }
 }
@@ -92,11 +93,12 @@ This keeps everything in one place:
 | Field | Required | Description |
 | --- | --- | --- |
 | `logseq_graph_path` | ✅ | Path to your Logseq graph directory (contains `pages/` and `journals/`) |
+| `exclude_tags` | no | **Project-level privacy filter** — pages with these tags are hidden from all tools (list, search, query, get content) *and* excluded from the vector index. Use this for pages with sensitive content (e.g. API keys, personal notes). |
 | `vector.enabled` | ✅ | Must be `true` to activate vector tools |
 | `vector.db_path` | ✅ | Where to store the vector DB — keep it local, not in iCloud |
 | `vector.embedder.model` | ✅ | Ollama model name — must match what you pulled |
 | `vector.include_journals` | no | Index journal pages (default: `true`) |
-| `vector.exclude_tags` | no | Skip pages with these tags (default: `[]`) |
+| `vector.exclude_tags` | no | Additional tags to skip from the vector index only (additive with top-level `exclude_tags`). Use for noise filtering — e.g. large reference dumps that pollute semantic search but are fine to read directly. (default: `[]`) |
 | `vector.min_chunk_length` | no | Minimum characters per chunk (default: `50`) |
 
 **Important:** keep `db_path` outside your iCloud-synced Logseq folder. The DB is a generated binary artifact — syncing it to iCloud wastes bandwidth and can cause corruption.
@@ -271,5 +273,5 @@ Large graphs with `qwen3-embedding:8b` take ~20s per batch of 32 chunks. A graph
 
 Run `vector_db_status` to check chunk and page counts. If a page is missing, it may have been skipped due to:
 - All chunks being under `min_chunk_length`
-- The page having a tag listed in `exclude_tags`
+- The page having a tag listed in `exclude_tags` (top-level or `vector.exclude_tags`)
 - A timeout during the initial sync (run `--once` again to pick it up)

--- a/src/mcp_logseq/config.py
+++ b/src/mcp_logseq/config.py
@@ -7,6 +7,7 @@ If not set, or if vector.enabled is false/missing, vector tools are not loaded.
 Example config.json:
 {
   "logseq_graph_path": "/path/to/logseq/pages",
+  "exclude_tags": ["private", "secret"],
   "vector": {
     "enabled": true,
     "db_path": "~/.logseq-vector",
@@ -107,3 +108,41 @@ def load_vector_config() -> VectorConfig | None:
         min_chunk_length=vector_raw.get("min_chunk_length", 50),
         watch_debounce_ms=vector_raw.get("watch_debounce_ms", 5000),
     )
+
+
+def load_exclude_tags() -> list[str]:
+    """
+    Load top-level exclude_tags from LOGSEQ_EXCLUDE_TAGS env var or config file root.
+    Priority: env var > config file > [] (no filtering).
+    Never raises.
+    """
+    env_val = os.getenv("LOGSEQ_EXCLUDE_TAGS", "").strip()
+    if env_val:
+        tags = [t.strip() for t in env_val.split(",") if t.strip()]
+        if tags:
+            logger.info(f"Loaded {len(tags)} exclude_tags from LOGSEQ_EXCLUDE_TAGS")
+            return tags
+
+    config_path = os.getenv("LOGSEQ_CONFIG_FILE")
+    if not config_path:
+        return []
+    config_path = os.path.expanduser(config_path)
+    if not os.path.exists(config_path):
+        return []
+    try:
+        with open(config_path) as f:
+            raw = json.load(f)
+    except Exception as e:
+        logger.warning(f"Failed to parse config file for exclude_tags {config_path}: {e}")
+        return []
+
+    raw_tags = raw.get("exclude_tags", [])
+    if isinstance(raw_tags, list):
+        tags = [str(t).strip() for t in raw_tags if str(t).strip()]
+    elif isinstance(raw_tags, str):
+        tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+    else:
+        tags = []
+    if tags:
+        logger.info(f"Loaded {len(tags)} exclude_tags from config file root")
+    return tags

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -100,8 +100,13 @@ logger.info("Tool handlers registration complete")
 # Conditional vector tool registration — only when LOGSEQ_CONFIG_FILE is set
 # and vector.enabled is true in the config file
 try:
-    from .config import load_vector_config
+    from .config import load_vector_config, load_exclude_tags
     vector_config = load_vector_config()
+    # Merge top-level exclude_tags into vector config (additive union)
+    top_level_exclude = load_exclude_tags()
+    if vector_config and top_level_exclude:
+        merged = list(dict.fromkeys(top_level_exclude + vector_config.exclude_tags))
+        vector_config.exclude_tags = merged
     if vector_config and vector_config.enabled:
         from .vector.index import (
             VectorDBStatusToolHandler,

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -6,6 +6,7 @@ from typing import Any
 from urllib.parse import urlparse
 from . import logseq
 from . import parser
+from .config import load_exclude_tags
 from mcp.types import Tool, TextContent
 
 logger = logging.getLogger("mcp-logseq")
@@ -30,6 +31,7 @@ else:
     _api_verify_ssl = _api_protocol == "https"
 
 _db_mode = os.getenv("LOGSEQ_DB_MODE", "").lower() in ("1", "true", "yes")
+_exclude_tags: list[str] = load_exclude_tags()
 
 
 def _make_api() -> logseq.LogSeq:
@@ -68,6 +70,24 @@ def _resolve_block_refs(content: str, uuid_map: dict[str, str]) -> str:
         return match.group(0)  # Keep original if not resolved
 
     return _UUID_REF_PATTERN.sub(_replace, content)
+
+
+def _extract_tags(properties: dict) -> list[str]:
+    """Extract tags from a Logseq properties dict (list or comma-string form)."""
+    raw = properties.get("tags", [])
+    if isinstance(raw, str):
+        return [t.strip() for t in raw.split(",") if t.strip()]
+    elif isinstance(raw, list):
+        return [str(t).strip() for t in raw if str(t).strip()]
+    return []
+
+
+def _is_page_excluded(page: dict, exclude_tags: list[str]) -> bool:
+    """Return True if the page has any tag in exclude_tags."""
+    if not exclude_tags:
+        return False
+    props = page.get("properties") or {}
+    return any(t in exclude_tags for t in _extract_tags(props))
 
 
 class ToolHandler:
@@ -220,6 +240,9 @@ class ListPagesToolHandler(ToolHandler):
                 # Skip if it's a journal page and we don't want to include those
                 is_journal = page.get("journal?", False)
                 if is_journal and not include_journals:
+                    continue
+                # Security: pages with excluded tags are invisible
+                if _is_page_excluded(page, _exclude_tags):
                     continue
 
                 # Get page information
@@ -375,6 +398,13 @@ class GetPageContentToolHandler(ToolHandler):
                         type="text", text=f"Page '{args['page_name']}' not found."
                     )
                 ]
+
+            # Security: block access to excluded pages — fail loudly
+            if _exclude_tags and _is_page_excluded(result.get("page", {}), _exclude_tags):
+                raise RuntimeError(
+                    f"Access denied: page '{args['page_name']}' is restricted "
+                    f"and cannot be read by this assistant."
+                )
 
             # Handle JSON format request
             if args.get("format") == "json":
@@ -836,9 +866,31 @@ class SearchToolHandler(ToolHandler):
         )
 
     @staticmethod
+    def _build_excluded_page_names(api, exclude_tags: list[str]) -> set[str]:
+        """Return lowercased names of pages that have excluded tags.
+
+        Makes one extra api.list_pages() call. Fails open on error to avoid
+        breaking search entirely when exclude_tags is configured.
+        """
+        if not exclude_tags:
+            return set()
+        try:
+            pages = api.list_pages()
+            return {
+                (page.get("originalName") or page.get("name", "")).lower()
+                for page in pages
+                if _is_page_excluded(page, exclude_tags)
+                and (page.get("originalName") or page.get("name"))
+            }
+        except Exception as e:
+            logger.warning(f"Could not build excluded page names for search filtering: {e}")
+            return set()
+
+    @staticmethod
     def _format_db_mode_results(
         result: dict, limit: int,
         include_blocks: bool, include_pages: bool, include_files: bool,
+        excluded_page_names: set[str] = frozenset(),
     ) -> list[str]:
         """Format search results from DB-mode Logseq.
 
@@ -854,11 +906,17 @@ class SearchToolHandler(ToolHandler):
         block_results = [b for b in blocks if not b.get("page?")]
 
         if include_pages and page_results:
-            parts.append(f"## Matching Pages ({len(page_results)} found)")
-            for page in page_results:
-                name = page.get("fullTitle") or page.get("title") or page.get("content", "")
-                parts.append(f"- {name}")
-            parts.append("")
+            visible_pages = [
+                p for p in page_results
+                if (p.get("fullTitle") or p.get("title") or p.get("content", "")).lower()
+                not in excluded_page_names
+            ]
+            if visible_pages:
+                parts.append(f"## Matching Pages ({len(visible_pages)} found)")
+                for page in visible_pages:
+                    name = page.get("fullTitle") or page.get("title") or page.get("content", "")
+                    parts.append(f"- {name}")
+                parts.append("")
 
         if include_blocks and block_results:
             parts.append(f"## Content Blocks ({len(block_results)} found)")
@@ -892,6 +950,7 @@ class SearchToolHandler(ToolHandler):
     def _format_markdown_mode_results(
         result: dict, limit: int,
         include_blocks: bool, include_pages: bool, include_files: bool,
+        excluded_page_names: set[str] = frozenset(),
     ) -> list[str]:
         """Format search results from markdown-mode Logseq.
 
@@ -914,24 +973,29 @@ class SearchToolHandler(ToolHandler):
 
         if include_pages and result.get("pages-content"):
             snippets = result["pages-content"]
-            parts.append(f"## Page Snippets ({len(snippets)} found)")
-            for i, snippet in enumerate(snippets[:limit]):
-                snippet_text = snippet.get("block/snippet", "").strip()
-                if snippet_text:
-                    snippet_text = snippet_text.replace("$pfts_2lqh>$", "").replace(
-                        "$<pfts_2lqh$", ""
-                    )
-                    if len(snippet_text) > 200:
-                        snippet_text = snippet_text[:200] + "..."
-                    parts.append(f"{i + 1}. {snippet_text}")
-            parts.append("")
+            if not excluded_page_names:
+                # Only show snippets when no exclusion is active — snippets carry no
+                # page identifier so we cannot verify they are safe to show
+                parts.append(f"## Page Snippets ({len(snippets)} found)")
+                for i, snippet in enumerate(snippets[:limit]):
+                    snippet_text = snippet.get("block/snippet", "").strip()
+                    if snippet_text:
+                        snippet_text = snippet_text.replace("$pfts_2lqh>$", "").replace(
+                            "$<pfts_2lqh$", ""
+                        )
+                        if len(snippet_text) > 200:
+                            snippet_text = snippet_text[:200] + "..."
+                        parts.append(f"{i + 1}. {snippet_text}")
+                parts.append("")
 
         if include_pages and result.get("pages"):
             pages = result["pages"]
-            parts.append(f"## Matching Pages ({len(pages)} found)")
-            for page in pages:
-                parts.append(f"- {page}")
-            parts.append("")
+            visible_pages = [p for p in pages if p.lower() not in excluded_page_names]
+            if visible_pages:
+                parts.append(f"## Matching Pages ({len(visible_pages)} found)")
+                for page in visible_pages:
+                    parts.append(f"- {page}")
+                parts.append("")
 
         if include_files and result.get("files"):
             files = result["files"]
@@ -979,17 +1043,20 @@ class SearchToolHandler(ToolHandler):
                     )
                 ]
 
+            # Build excluded page name set (one extra API call only when needed)
+            excluded_page_names = self._build_excluded_page_names(api, _exclude_tags)
+
             # Format results
             content_parts = []
             content_parts.append(f"# Search Results for '{query}'\n")
 
             if _db_mode:
                 content_parts.extend(
-                    self._format_db_mode_results(result, limit, include_blocks, include_pages, include_files)
+                    self._format_db_mode_results(result, limit, include_blocks, include_pages, include_files, excluded_page_names)
                 )
             else:
                 content_parts.extend(
-                    self._format_markdown_mode_results(result, limit, include_blocks, include_pages, include_files)
+                    self._format_markdown_mode_results(result, limit, include_blocks, include_pages, include_files, excluded_page_names)
                 )
 
             response_text = "\n".join(content_parts)
@@ -1103,6 +1170,15 @@ class QueryToolHandler(ToolHandler):
                 if result_type == "blocks_only" and not self._is_block(item):
                     continue
                 filtered_results.append(item)
+
+            # Security: filter page objects with excluded tags
+            if _exclude_tags:
+                exclude_filtered = []
+                for item in filtered_results:
+                    if self._is_page(item) and _is_page_excluded(item, _exclude_tags):
+                        continue
+                    exclude_filtered.append(item)
+                filtered_results = exclude_filtered
 
             if not filtered_results:
                 filter_msg = f" (filtered to {result_type})" if result_type != "all" else ""

--- a/tests/unit/test_exclude_tags.py
+++ b/tests/unit/test_exclude_tags.py
@@ -1,0 +1,419 @@
+"""Tests for the exclude_tags security feature.
+
+Covers:
+- load_exclude_tags() config loading (env var, config file, priority)
+- _extract_tags() and _is_page_excluded() helper functions
+- ListPagesToolHandler filtering
+- GetPageContentToolHandler access denial
+- SearchToolHandler page filtering
+- QueryToolHandler page object filtering
+"""
+
+import json
+import pytest
+from unittest.mock import patch, Mock
+
+from mcp_logseq.config import load_exclude_tags
+from mcp_logseq.tools import (
+    _extract_tags,
+    _is_page_excluded,
+    ListPagesToolHandler,
+    GetPageContentToolHandler,
+    SearchToolHandler,
+    QueryToolHandler,
+)
+
+
+# =============================================================================
+# load_exclude_tags()
+# =============================================================================
+
+
+def test_returns_empty_when_nothing_set(monkeypatch):
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    monkeypatch.delenv("LOGSEQ_CONFIG_FILE", raising=False)
+    assert load_exclude_tags() == []
+
+
+def test_reads_from_env_var(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_EXCLUDE_TAGS", "private,secret")
+    monkeypatch.delenv("LOGSEQ_CONFIG_FILE", raising=False)
+    assert load_exclude_tags() == ["private", "secret"]
+
+
+def test_env_var_strips_whitespace(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_EXCLUDE_TAGS", " private , secret ")
+    monkeypatch.delenv("LOGSEQ_CONFIG_FILE", raising=False)
+    assert load_exclude_tags() == ["private", "secret"]
+
+
+def test_env_var_takes_priority_over_config_file(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"exclude_tags": ["from-file"]}))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.setenv("LOGSEQ_EXCLUDE_TAGS", "from-env")
+    assert load_exclude_tags() == ["from-env"]
+
+
+def test_reads_from_config_file(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"exclude_tags": ["private", "draft"]}))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    assert load_exclude_tags() == ["private", "draft"]
+
+
+def test_config_file_comma_string_form(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"exclude_tags": "private, draft"}))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    assert load_exclude_tags() == ["private", "draft"]
+
+
+def test_returns_empty_when_config_file_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(tmp_path / "nonexistent.json"))
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    assert load_exclude_tags() == []
+
+
+def test_returns_empty_when_config_file_malformed(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text("not valid json{{{")
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    assert load_exclude_tags() == []
+
+
+def test_returns_empty_when_config_has_no_exclude_tags_key(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"logseq_graph_path": "/some/path"}))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.delenv("LOGSEQ_EXCLUDE_TAGS", raising=False)
+    assert load_exclude_tags() == []
+
+
+def test_env_var_empty_string_falls_through_to_config(monkeypatch, tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"exclude_tags": ["from-file"]}))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.setenv("LOGSEQ_EXCLUDE_TAGS", "")
+    assert load_exclude_tags() == ["from-file"]
+
+
+# =============================================================================
+# _extract_tags() and _is_page_excluded()
+# =============================================================================
+
+
+def test_extract_tags_list_form():
+    assert _extract_tags({"tags": ["private", "draft"]}) == ["private", "draft"]
+
+
+def test_extract_tags_string_form():
+    assert _extract_tags({"tags": "private, draft"}) == ["private", "draft"]
+
+
+def test_extract_tags_missing_key():
+    assert _extract_tags({}) == []
+
+
+def test_extract_tags_empty_list():
+    assert _extract_tags({"tags": []}) == []
+
+
+def test_extract_tags_strips_whitespace():
+    assert _extract_tags({"tags": " private , draft "}) == ["private", "draft"]
+
+
+def test_is_page_excluded_true():
+    page = {"properties": {"tags": ["private", "notes"]}}
+    assert _is_page_excluded(page, ["private"]) is True
+
+
+def test_is_page_excluded_false():
+    page = {"properties": {"tags": ["public", "notes"]}}
+    assert _is_page_excluded(page, ["private"]) is False
+
+
+def test_is_page_excluded_empty_exclude_list():
+    page = {"properties": {"tags": ["private"]}}
+    assert _is_page_excluded(page, []) is False
+
+
+def test_is_page_excluded_no_properties_key():
+    page = {"name": "Some Page"}
+    assert _is_page_excluded(page, ["private"]) is False
+
+
+def test_is_page_excluded_none_properties():
+    page = {"properties": None}
+    assert _is_page_excluded(page, ["private"]) is False
+
+
+# =============================================================================
+# ListPagesToolHandler
+# =============================================================================
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_list_pages_excludes_tagged_pages(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.list_pages.return_value = [
+        {"originalName": "Public Page", "journal?": False, "properties": {"tags": ["notes"]}},
+        {"originalName": "Secret Page", "journal?": False, "properties": {"tags": ["private"]}},
+        {"originalName": "Normal Page", "journal?": False, "properties": {}},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = ListPagesToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"include_journals": True})
+
+    text = result[0].text
+    assert "Public Page" in text
+    assert "Normal Page" in text
+    assert "Secret Page" not in text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_list_pages_no_filter_when_exclude_empty(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.list_pages.return_value = [
+        {"originalName": "Private Page", "journal?": False, "properties": {"tags": ["private"]}},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = ListPagesToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", []):
+        result = handler.run_tool({})
+
+    assert "Private Page" in result[0].text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_list_pages_multiple_excluded_tags(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.list_pages.return_value = [
+        {"originalName": "Secret", "journal?": False, "properties": {"tags": ["private"]}},
+        {"originalName": "Draft", "journal?": False, "properties": {"tags": ["draft"]}},
+        {"originalName": "Public", "journal?": False, "properties": {"tags": ["notes"]}},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = ListPagesToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private", "draft"]):
+        result = handler.run_tool({})
+
+    text = result[0].text
+    assert "Public" in text
+    assert "Secret" not in text
+    assert "Draft" not in text
+
+
+# =============================================================================
+# GetPageContentToolHandler
+# =============================================================================
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_get_page_content_raises_for_excluded_page(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.get_page_content.return_value = {
+        "page": {"originalName": "Secret Diary", "properties": {"tags": ["private"]}},
+        "blocks": [{"content": "top secret stuff", "children": []}],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = GetPageContentToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        with pytest.raises(RuntimeError, match="Access denied"):
+            handler.run_tool({"page_name": "Secret Diary"})
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_get_page_content_allows_non_excluded_page(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.get_page_content.return_value = {
+        "page": {"originalName": "Public Notes", "properties": {"tags": ["notes"]}},
+        "blocks": [{"content": "Some notes content", "children": []}],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = GetPageContentToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"page_name": "Public Notes"})
+
+    assert "Some notes content" in result[0].text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_get_page_content_no_block_when_exclude_empty(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.get_page_content.return_value = {
+        "page": {"originalName": "Private Page", "properties": {"tags": ["private"]}},
+        "blocks": [{"content": "private content", "children": []}],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = GetPageContentToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", []):
+        result = handler.run_tool({"page_name": "Private Page"})
+
+    assert "private content" in result[0].text
+
+
+# =============================================================================
+# SearchToolHandler
+# =============================================================================
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_search_filters_excluded_page_names(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.list_pages.return_value = [
+        {"originalName": "Secret Page", "journal?": False, "properties": {"tags": ["private"]}},
+        {"originalName": "Public Page", "journal?": False, "properties": {}},
+    ]
+    mock_api.search_content.return_value = {
+        "blocks": [],
+        "pages": ["Secret Page", "Public Page"],
+        "pages-content": [],
+        "files": [],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = SearchToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"query": "test"})
+
+    text = result[0].text
+    assert "Public Page" in text
+    assert "Secret Page" not in text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_search_no_extra_api_call_when_no_exclude_tags(mock_logseq_class):
+    """list_pages should NOT be called when _exclude_tags is empty."""
+    mock_api = Mock()
+    mock_api.search_content.return_value = {
+        "blocks": [],
+        "pages": ["Some Page"],
+        "pages-content": [],
+        "files": [],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = SearchToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", []):
+        handler.run_tool({"query": "test"})
+
+    mock_api.list_pages.assert_not_called()
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_search_snippets_dropped_when_exclusion_active(mock_logseq_class):
+    """pages-content snippets are dropped when excluded_page_names is non-empty."""
+    mock_api = Mock()
+    mock_api.list_pages.return_value = [
+        {"originalName": "Private", "journal?": False, "properties": {"tags": ["private"]}},
+    ]
+    mock_api.search_content.return_value = {
+        "blocks": [],
+        "pages": [],
+        "pages-content": [{"block/snippet": "some secret snippet"}],
+        "files": [],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = SearchToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"query": "test"})
+
+    assert "some secret snippet" not in result[0].text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_search_snippets_shown_when_no_exclusion(mock_logseq_class):
+    """pages-content snippets are shown when _exclude_tags is empty."""
+    mock_api = Mock()
+    mock_api.search_content.return_value = {
+        "blocks": [],
+        "pages": [],
+        "pages-content": [{"block/snippet": "a visible snippet"}],
+        "files": [],
+    }
+    mock_logseq_class.return_value = mock_api
+
+    handler = SearchToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", []):
+        result = handler.run_tool({"query": "test"})
+
+    assert "a visible snippet" in result[0].text
+
+
+# =============================================================================
+# QueryToolHandler
+# =============================================================================
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_query_filters_excluded_page_objects(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.query_dsl.return_value = [
+        {"originalName": "Public Page", "name": "public-page", "properties": {"tags": ["notes"]}},
+        {"originalName": "Private Page", "name": "private-page", "properties": {"tags": ["private"]}},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = QueryToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"query": "(page-property type x)"})
+
+    text = result[0].text
+    assert "Public Page" in text
+    assert "Private Page" not in text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_query_block_objects_pass_through(mock_logseq_class):
+    """Block objects (no page properties) are not filtered."""
+    mock_api = Mock()
+    mock_api.query_dsl.return_value = [
+        {"content": "A block result with no page props", "uuid": "some-uuid"},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = QueryToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        result = handler.run_tool({"query": "(page-property type x)"})
+
+    assert "A block result" in result[0].text
+
+
+@patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+@patch("mcp_logseq.tools.logseq.LogSeq")
+def test_query_no_filter_when_exclude_empty(mock_logseq_class):
+    mock_api = Mock()
+    mock_api.query_dsl.return_value = [
+        {"originalName": "Private Page", "name": "private-page", "properties": {"tags": ["private"]}},
+    ]
+    mock_logseq_class.return_value = mock_api
+
+    handler = QueryToolHandler()
+    with patch("mcp_logseq.tools._exclude_tags", []):
+        result = handler.run_tool({"query": "(page-property type x)"})
+
+    assert "Private Page" in result[0].text


### PR DESCRIPTION
## Summary

- Adds top-level `exclude_tags` config that hides pages from all MCP tools (list, get, search, query) and the vector index
- Pages with excluded tags are invisible in `list_pages`, filtered from `search` and `query` results, and trigger a clear access-denied error in `get_page_content`
- Configure via `LOGSEQ_EXCLUDE_TAGS=private,secret` env var or `"exclude_tags": [...]` in the JSON config file
- `vector.exclude_tags` is preserved for additive noise-filtering; top-level tags are automatically merged into it so private pages are never embedded

## Test plan

- [ ] Run `uv run pytest tests/unit/test_exclude_tags.py -v` — 33 new tests pass
- [ ] Run `uv run pytest -v` — all 378 tests pass, no regressions
- [ ] Manual: tag a Logseq page with `tags:: private`, set `LOGSEQ_EXCLUDE_TAGS=private`, verify page absent from `list_pages` and access denied on `get_page_content`