### PR TITLE
refactor: _acquire_sync_lock should raise instead of calling sys.exit

### DIFF
--- a/src/mcp_logseq/bin/logseq_sync.py
+++ b/src/mcp_logseq/bin/logseq_sync.py
@@ -52,12 +52,10 @@ def _acquire_sync_lock(db_path: str):
         return lock_file
     except portalocker.LockException:
         lock_file.close()
-        print(
-            "Error: another sync process is already running. "
-            "Wait for it to finish or check for stale sync.lock.",
-            file=sys.stderr,
+        raise RuntimeError(
+            "Another sync process is already running. "
+            "Wait for it to finish or check for stale sync.lock."
         )
-        sys.exit(1)
 
 
 def _release_sync_lock(lock_file):
@@ -87,7 +85,13 @@ def _run_sync(config, rebuild: bool = False) -> None:
     from mcp_logseq.vector.state import StateManager
     from mcp_logseq.vector.sync import SyncEngine
 
-    lock_file = _acquire_sync_lock(config.db_path)
+    lock_file = None
+    try:
+        lock_file = _acquire_sync_lock(config.db_path)
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
     try:
         print(f"Connecting to Ollama ({config.embedder.model})...")
         try:
@@ -114,7 +118,8 @@ def _run_sync(config, rebuild: bool = False) -> None:
 
         db.close()
     finally:
-        _release_sync_lock(lock_file)
+        if lock_file is not None:
+            _release_sync_lock(lock_file)
 
     print(
         f"Done in {result.duration_ms}ms: "

--- a/tests/unit/vector/test_logseq_sync.py
+++ b/tests/unit/vector/test_logseq_sync.py
@@ -30,12 +30,9 @@ def test_acquire_lock_conflict_exits(tmp_path, capsys):
     portalocker.lock(holder, portalocker.LOCK_EX | portalocker.LOCK_NB)
 
     try:
-        with patch("sys.exit") as mock_exit:
+        with pytest.raises(RuntimeError) as exc:
             _acquire_sync_lock(str(tmp_path))
-            mock_exit.assert_called_once_with(1)
-
-        captured = capsys.readouterr()
-        assert "another sync process is already running" in captured.err
+        assert "Another sync process is already running" in str(exc.value)
     finally:
         portalocker.unlock(holder)
         holder.close()


### PR DESCRIPTION
Fixes #37

Background
---------
`_acquire_sync_lock` previously called `sys.exit(1)` when it couldn't acquire the inter-process file lock. That makes the helper decide process termination and makes the function harder to test and harder for callers to handle gracefully.

Change
------
- `src/mcp_logseq/bin/logseq_sync.py`: `_acquire_sync_lock` now raises `RuntimeError` on lock conflict instead of calling `sys.exit(1)`.
- `_run_sync` now catches that `RuntimeError`, prints the error to `stderr`, and exits at the caller boundary. The lock release is guarded to avoid releasing a `None` handle.
- `tests/unit/vector/test_logseq_sync.py`: updated the lock-conflict test to expect `RuntimeError` and validate the message.

Why
---
This separates concerns (reporting the error vs deciding how to handle it), improves testability, and allows callers to handle lock conflicts (e.g., retry, log, or exit) as appropriate.

Tests
-----
- Ran full test suite locally: 378 passed.

Notes
-----
- I did not run `pyright` in this environment; I can run type checks and update the PR if you want.

