### PR TITLE
Make Logseq API timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ def hello():
 ### Environment Variables
 - **`LOGSEQ_API_TOKEN`** (required): Your LogSeq API token
 - **`LOGSEQ_API_URL`** (optional): Server URL (default: `http://localhost:12315`)
+- **`LOGSEQ_API_CONNECT_TIMEOUT`** (optional): HTTP connect timeout in seconds (default: `3`)
+- **`LOGSEQ_API_READ_TIMEOUT`** (optional): HTTP read timeout in seconds (default: `6`)
 - **`LOGSEQ_DB_MODE`** (optional): Set to `true` to enable DB-mode property support. Only for Logseq DB-mode graphs (beta). Markdown/file-based graph users should leave this unset.
 - **`LOGSEQ_EXCLUDE_TAGS`** (optional): Comma-separated tags — pages with these tags are hidden from all tools. See [Privacy & Access Control](#-privacy--access-control) below.
 

--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -13,13 +13,14 @@ class LogSeq:
         host: str = "127.0.0.1",
         port: int = 12315,
         verify_ssl: bool = False,
+        timeout: tuple[float, float] | None = None,
     ):
         self.api_key = api_key
         self.protocol = protocol
         self.host = host
         self.port = port
         self.verify_ssl = verify_ssl
-        self.timeout = (3, 6)
+        self.timeout = timeout or (3, 6)
 
     def get_base_url(self) -> str:
         return f"{self.protocol}://{self.host}:{self.port}/api"

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1,4 +1,5 @@
 import json
+import math
 import os
 import re
 import logging
@@ -32,13 +33,9 @@ def _parse_positive_float_env(name: str, default: float) -> float:
     try:
         value = float(raw_value)
     except ValueError:
-        logger.warning(
-            f"{name} must be a positive number of seconds, got {raw_value!r}; "
-            f"falling back to default {default}"
-        )
-        return default
+        value = None
 
-    if value <= 0:
+    if value is None or not math.isfinite(value) or value <= 0:
         logger.warning(
             f"{name} must be a positive number of seconds, got {raw_value!r}; "
             f"falling back to default {default}"

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -31,11 +31,19 @@ def _parse_positive_float_env(name: str, default: float) -> float:
 
     try:
         value = float(raw_value)
-    except ValueError as e:
-        raise ValueError(f"{name} must be a positive number of seconds") from e
+    except ValueError:
+        logger.warning(
+            f"{name} must be a positive number of seconds, got {raw_value!r}; "
+            f"falling back to default {default}"
+        )
+        return default
 
     if value <= 0:
-        raise ValueError(f"{name} must be a positive number of seconds")
+        logger.warning(
+            f"{name} must be a positive number of seconds, got {raw_value!r}; "
+            f"falling back to default {default}"
+        )
+        return default
 
     return value
 

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -24,6 +24,26 @@ _api_protocol = _parsed_url.scheme or "http"
 _api_host = _parsed_url.hostname or "127.0.0.1"
 _api_port = _parsed_url.port or 12315
 
+def _parse_positive_float_env(name: str, default: float) -> float:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return default
+
+    try:
+        value = float(raw_value)
+    except ValueError as e:
+        raise ValueError(f"{name} must be a positive number of seconds") from e
+
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive number of seconds")
+
+    return value
+
+
+_api_connect_timeout = _parse_positive_float_env("LOGSEQ_API_CONNECT_TIMEOUT", 3)
+_api_read_timeout = _parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6)
+_api_timeout = (_api_connect_timeout, _api_read_timeout)
+
 _verify_ssl_env = os.getenv("LOGSEQ_VERIFY_SSL")
 if _verify_ssl_env is not None:
     _api_verify_ssl = _verify_ssl_env.lower() not in ("0", "false", "no")
@@ -41,6 +61,7 @@ def _make_api() -> logseq.LogSeq:
         host=_api_host,
         port=_api_port,
         verify_ssl=_api_verify_ssl,
+        timeout=_api_timeout,
     )
 
 

--- a/tests/unit/test_logseq_api.py
+++ b/tests/unit/test_logseq_api.py
@@ -20,6 +20,12 @@ class TestLogSeqAPI:
         assert client.verify_ssl == False
         assert client.timeout == (3, 6)
 
+    def test_init_with_custom_timeout(self, mock_api_key):
+        """Test LogSeq client initialization with custom request timeout."""
+        client = LogSeq(api_key=mock_api_key, timeout=(5, 60))
+
+        assert client.timeout == (5, 60)
+
     def test_init_with_custom_params(self, mock_api_key):
         """Test LogSeq client initialization with custom parameters."""
         client = LogSeq(

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -34,9 +34,16 @@ class TestToolConfiguration:
         assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 60
 
     @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "0"})
-    def test_parse_positive_float_env_rejects_non_positive_values(self):
-        with pytest.raises(ValueError, match="LOGSEQ_API_READ_TIMEOUT"):
-            tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6)
+    def test_parse_positive_float_env_non_positive_falls_back_to_default(self):
+        with patch.object(tools.logger, "warning") as mock_warning:
+            assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
+        mock_warning.assert_called_once()
+
+    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "fast"})
+    def test_parse_positive_float_env_invalid_falls_back_to_default(self):
+        with patch.object(tools.logger, "warning") as mock_warning:
+            assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
+        mock_warning.assert_called_once()
 
     @patch("mcp_logseq.tools.logseq.LogSeq")
     def test_make_api_passes_configured_timeout(self, mock_logseq_class):

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -45,6 +45,13 @@ class TestToolConfiguration:
             assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
         mock_warning.assert_called_once()
 
+    @pytest.mark.parametrize("raw_value", ["nan", "inf", "-inf"])
+    def test_parse_positive_float_env_non_finite_falls_back_to_default(self, raw_value):
+        with patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": raw_value}):
+            with patch.object(tools.logger, "warning") as mock_warning:
+                assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
+            mock_warning.assert_called_once()
+
     @patch("mcp_logseq.tools.logseq.LogSeq")
     def test_make_api_passes_configured_timeout(self, mock_logseq_class):
         original_timeout = tools._api_timeout

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import patch, Mock
 from mcp.types import TextContent
+import mcp_logseq.tools as tools
 from mcp_logseq.tools import (
     CreatePageToolHandler,
     ListPagesToolHandler,
@@ -19,6 +20,35 @@ from mcp_logseq.tools import (
     GetPageBacklinksToolHandler,
     InsertNestedBlockToolHandler,
 )
+
+
+class TestToolConfiguration:
+    """Test cases for module-level tool configuration."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_parse_positive_float_env_uses_default(self):
+        assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
+
+    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "60"})
+    def test_parse_positive_float_env_uses_override(self):
+        assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 60
+
+    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "0"})
+    def test_parse_positive_float_env_rejects_non_positive_values(self):
+        with pytest.raises(ValueError, match="LOGSEQ_API_READ_TIMEOUT"):
+            tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6)
+
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_make_api_passes_configured_timeout(self, mock_logseq_class):
+        original_timeout = tools._api_timeout
+        try:
+            tools._api_timeout = (3, 60)
+
+            tools._make_api()
+
+            assert mock_logseq_class.call_args.kwargs["timeout"] == (3, 60)
+        finally:
+            tools._api_timeout = original_timeout
 
 
 class TestCreatePageToolHandler:


### PR DESCRIPTION
- Add optional `LOGSEQ_API_CONNECT_TIMEOUT` and `LOGSEQ_API_READ_TIMEOUT` environment variables.
- Preserve the current `(3, 6)` timeout defaults when the env vars are unset.
- Pass the configured timeout tuple into the `LogSeq` client and document the new options.

Closes #46