### PR TITLE
fix: preserve multiline markdown blocks

### DIFF
--- a/src/mcp_logseq/parser.py
+++ b/src/mcp_logseq/parser.py
@@ -358,19 +358,27 @@ class MarkdownParser:
         Logseq block content may contain newlines; splitting these delimiters into
         separate blocks breaks KaTeX rendering.
         """
-        math_lines = [lines[start].rstrip()]
+        math_block, i = self._parse_display_math_node(lines, start)
+        self._add_block(math_block)
+
+        return i
+
+    def _parse_display_math_node(
+        self, lines: list[str], start: int
+    ) -> tuple[BlockNode, int]:
+        """Parse a $$...$$ display math block into one block node."""
+        math_lines = [lines[start].strip()]
         i = start + 1
 
         while i < len(lines):
-            math_lines.append(lines[i].rstrip())
+            math_lines.append(lines[i].strip())
             if DISPLAY_MATH_DELIMITER.match(lines[i]):
+                i += 1
                 break
             i += 1
 
         math_content = "\n".join(math_lines)
-        self._add_block(BlockNode(content=math_content, level=0))
-
-        return i + 1
+        return BlockNode(content=math_content, level=0), i
 
     def _parse_blockquote(self, lines: list[str], start: int) -> int:
         """
@@ -464,7 +472,10 @@ class MarkdownParser:
                 break
 
             # Nested content - parse recursively
-            if TABLE_ROW_PATTERN.match(next_line):
+            if DISPLAY_MATH_DELIMITER.match(next_line):
+                nested_block, i = self._parse_display_math_node(lines, i)
+                list_block.children.append(nested_block)
+            elif TABLE_ROW_PATTERN.match(next_line):
                 nested_block, i = self._parse_table_node(lines, i)
                 list_block.children.append(nested_block)
             elif (
@@ -524,7 +535,10 @@ class MarkdownParser:
                 break
 
             # Deeper nested content
-            if TABLE_ROW_PATTERN.match(next_line):
+            if DISPLAY_MATH_DELIMITER.match(next_line):
+                nested_block, i = self._parse_display_math_node(lines, i)
+                list_block.children.append(nested_block)
+            elif TABLE_ROW_PATTERN.match(next_line):
                 nested_block, i = self._parse_table_node(lines, i)
                 list_block.children.append(nested_block)
             elif (

--- a/src/mcp_logseq/parser.py
+++ b/src/mcp_logseq/parser.py
@@ -65,6 +65,7 @@ FENCED_CODE_START = re.compile(r"^(\s*)```(\w*)(.*)$")
 LOGSEQ_PROPERTY_PATTERN = re.compile(r"^\s*\w[\w-]*::\s")
 FENCED_CODE_END = re.compile(r"^(\s*)```\s*$")
 TABLE_ROW_PATTERN = re.compile(r"^\s*\|.+\|\s*$")
+DISPLAY_MATH_DELIMITER = re.compile(r"^\s*\$\$\s*$")
 
 
 def _serialize_frontmatter_value(obj: Any) -> Any:
@@ -249,6 +250,11 @@ class MarkdownParser:
                 i = self._parse_fenced_code(lines, i)
                 continue
 
+            # Check for display math block
+            if DISPLAY_MATH_DELIMITER.match(line):
+                i = self._parse_display_math(lines, i)
+                continue
+
             # Check for heading
             heading_level = _get_heading_level(line)
             if heading_level > 0:
@@ -345,6 +351,27 @@ class MarkdownParser:
 
         return i + 1
 
+    def _parse_display_math(self, lines: list[str], start: int) -> int:
+        """
+        Parse a $$...$$ display math block as a single Logseq block.
+
+        Logseq block content may contain newlines; splitting these delimiters into
+        separate blocks breaks KaTeX rendering.
+        """
+        math_lines = [lines[start].rstrip()]
+        i = start + 1
+
+        while i < len(lines):
+            math_lines.append(lines[i].rstrip())
+            if DISPLAY_MATH_DELIMITER.match(lines[i]):
+                break
+            i += 1
+
+        math_content = "\n".join(math_lines)
+        self._add_block(BlockNode(content=math_content, level=0))
+
+        return i + 1
+
     def _parse_blockquote(self, lines: list[str], start: int) -> int:
         """
         Parse blockquote lines.
@@ -437,7 +464,10 @@ class MarkdownParser:
                 break
 
             # Nested content - parse recursively
-            if (
+            if TABLE_ROW_PATTERN.match(next_line):
+                nested_block, i = self._parse_table_node(lines, i)
+                list_block.children.append(nested_block)
+            elif (
                 CHECKBOX_PATTERN.match(next_line)
                 or BULLET_PATTERN.match(next_line)
                 or NUMBERED_PATTERN.match(next_line)
@@ -494,7 +524,10 @@ class MarkdownParser:
                 break
 
             # Deeper nested content
-            if (
+            if TABLE_ROW_PATTERN.match(next_line):
+                nested_block, i = self._parse_table_node(lines, i)
+                list_block.children.append(nested_block)
+            elif (
                 CHECKBOX_PATTERN.match(next_line)
                 or BULLET_PATTERN.match(next_line)
                 or NUMBERED_PATTERN.match(next_line)
@@ -517,25 +550,29 @@ class MarkdownParser:
 
         Returns the index of the next line to process.
         """
+        table_block, i = self._parse_table_node(lines, start)
+        if table_block.content:
+            self._add_block(table_block)
+
+        return i
+
+    def _parse_table_node(self, lines: list[str], start: int) -> tuple[BlockNode, int]:
+        """Parse contiguous markdown table rows into one block node."""
         table_lines = []
         i = start
 
         while i < len(lines):
             line = lines[i]
             if TABLE_ROW_PATTERN.match(line):
-                table_lines.append(line.rstrip())
+                table_lines.append(line.strip())
                 i += 1
             elif not line.strip():
-                # Empty line ends the table
                 break
             else:
                 break
 
-        if table_lines:
-            table_content = "\n".join(table_lines)
-            self._add_block(BlockNode(content=table_content, level=0))
-
-        return i
+        table_content = "\n".join(table_lines)
+        return BlockNode(content=table_content, level=0), i
 
     def _parse_paragraph(self, lines: list[str], start: int) -> int:
         """
@@ -562,6 +599,7 @@ class MarkdownParser:
                 or BLOCKQUOTE_PATTERN.match(line)
                 or HORIZONTAL_RULE_PATTERN.match(line)
                 or FENCED_CODE_START.match(line)
+                or DISPLAY_MATH_DELIMITER.match(line)
                 or LOGSEQ_PROPERTY_PATTERN.match(line)
                 or TABLE_ROW_PATTERN.match(line)
             ):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -461,6 +461,52 @@ $$
         assert len(blocks[0].children) == 1
         assert blocks[0].children[0].content == "$$\na^2 + b^2 = c^2\n$$"
 
+    def test_display_math_under_list_item_preserves_newlines(self):
+        """Display math under a list item should be one child block."""
+        content = """- Parent
+  $$
+  a^2 + b^2 = c^2
+  $$
+"""
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "Parent"
+        assert len(blocks[0].children) == 1
+        assert blocks[0].children[0].content == "$$\na^2 + b^2 = c^2\n$$"
+
+    def test_display_math_under_nested_list_item_preserves_newlines(self):
+        """Display math under a nested list item should be one grandchild block."""
+        content = """- Parent
+  - Child
+    $$
+    a^2 + b^2 = c^2
+    $$
+"""
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "Parent"
+        assert len(blocks[0].children) == 1
+        child = blocks[0].children[0]
+        assert child.content == "Child"
+        assert len(child.children) == 1
+        assert child.children[0].content == "$$\na^2 + b^2 = c^2\n$$"
+
+    def test_display_math_under_list_item_batch_format_preserves_newlines(self):
+        """End-to-end: nested display math in batch format keeps newlines."""
+        content = """- Parent
+  $$
+  a^2 + b^2 = c^2
+  $$
+"""
+        parsed = parse_content(content)
+        batch = parsed.to_batch_format()
+
+        assert len(batch) == 1
+        assert len(batch[0]["children"]) == 1
+        assert batch[0]["children"][0]["content"] == "$$\na^2 + b^2 = c^2\n$$"
+
 
 class TestParseMarkdownOther:
     """Tests for other markdown elements."""

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -432,6 +432,36 @@ console.log("hello");
         assert "```javascript" in blocks[0].children[0].content
 
 
+class TestParseMarkdownDisplayMath:
+    """Tests for display math block parsing."""
+
+    def test_display_math_preserves_newlines(self):
+        """Display math delimiters and body should stay in one block."""
+        content = """$$
+a^2 + b^2 = c^2
+$$
+"""
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "$$\na^2 + b^2 = c^2\n$$"
+
+    def test_display_math_under_heading(self):
+        """Display math under a heading should be a child block."""
+        content = """# Geometry
+
+$$
+a^2 + b^2 = c^2
+$$
+"""
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "# Geometry"
+        assert len(blocks[0].children) == 1
+        assert blocks[0].children[0].content == "$$\na^2 + b^2 = c^2\n$$"
+
+
 class TestParseMarkdownOther:
     """Tests for other markdown elements."""
 
@@ -935,3 +965,49 @@ class TestMarkdownTable:
 
         assert len(batch) == 1
         assert "\n" in batch[0]["content"]
+
+    def test_table_under_list_item_preserves_newlines(self):
+        """Table under a list item should be one child block."""
+        content = """- Parent
+  | A | B |
+  |---|---|
+  | 1 | 2 |"""
+
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "Parent"
+        assert len(blocks[0].children) == 1
+        assert blocks[0].children[0].content == "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_under_nested_list_item_preserves_newlines(self):
+        """Table under a nested list item should be one grandchild block."""
+        content = """- Parent
+  - Child
+    | A | B |
+    |---|---|
+    | 1 | 2 |"""
+
+        blocks = parse_markdown_to_blocks(content)
+
+        assert len(blocks) == 1
+        assert blocks[0].content == "Parent"
+        assert len(blocks[0].children) == 1
+        child = blocks[0].children[0]
+        assert child.content == "Child"
+        assert len(child.children) == 1
+        assert child.children[0].content == "| A | B |\n|---|---|\n| 1 | 2 |"
+
+    def test_table_under_list_item_batch_format_preserves_newlines(self):
+        """End-to-end: nested table content in batch format keeps newlines."""
+        content = """- Parent
+  | A | B |
+  |---|---|
+  | 1 | 2 |"""
+
+        parsed = parse_content(content)
+        batch = parsed.to_batch_format()
+
+        assert len(batch) == 1
+        assert len(batch[0]["children"]) == 1
+        assert "\n" in batch[0]["children"][0]["content"]


### PR DESCRIPTION
This PR fixes Markdown parsing cases where multiline content was split into multiple Logseq blocks before being inserted through the MCP server.

The issue was not caused by LaTeX or Markdown tables themselves, but by the MCP parser splitting some multiline constructs before sending them to Logseq.

## Bugs observed

### 1. Multiline LaTeX display equations

Input Markdown:

```markdown
$$
a^2 + b^2 = c^2
$$
Expected behavior:
The whole equation should be inserted as one Logseq block:
$$
a^2 + b^2 = c^2
$$
Problem:
The parser did not treat $$ ... $$ as an atomic multiline block. This could cause the opening delimiter, equation body, and closing delimiter to be handled separately, breaking KaTeX rendering in Logseq.
2. Markdown tables inside list items
Input Markdown:
- Parent
  | A | B |
  |---|---|
  | 1 | 2 |
Expected behavior:
Parent should have one child block containing the full table:
Parent
  child block:
    | A | B |
    |---|---|
    | 1 | 2 |
Problem:
Tables were already handled correctly at the root level, but not inside list parsing. When a table appeared under a list item, each table row was treated as a separate child block:
Parent
  child block: | A | B |
  child block: |---|---|
  child block: | 1 | 2 |
This broke table rendering because Markdown tables need their rows to stay together in the same block.
What changed
- Added dedicated parsing for display math blocks delimited by $$.
- $$ ... $$ content is now preserved as one block with newlines intact.
- Refactored table parsing into a reusable helper.
- Reused that helper inside normal list parsing and nested-list parsing.
- Added unit tests for:
- display math at root level;
- display math under headings;
- tables under list items;
- tables under nested list items;
- batch output preserving newlines.
Result
The parser now preserves multiline blocks before calling Logseq APIs.
For LaTeX:
$$
a^2 + b^2 = c^2
$$
is parsed as one block.
For tables inside lists:
- Parent
  | A | B |
  |---|---|
  | 1 | 2 |
is parsed as:
Parent
  child block:
    | A | B |
    |---|---|
    | 1 | 2 |
instead of three separate child blocks.
This keeps Logseq rendering intact for these multiline Markdown constructs.
```
