### PR TITLE
fix: guard against None page entity in get_page_backlinks

### DIFF
--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1562,6 +1562,10 @@ class GetPageBacklinksToolHandler(ToolHandler):
 
                 page_info, blocks = item[0], item[1]
 
+                # Guard against None page entity (can occur in Logseq DB mode)
+                if not isinstance(page_info, dict):
+                    continue
+
                 # Get page name
                 ref_page_name = page_info.get('originalName') or page_info.get('name', '<unknown>')
                 block_count = len(blocks) if blocks else 0

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -1439,6 +1439,38 @@ class TestGetPageBacklinksToolHandler:
         assert "1 reference" in text
 
     @patch.dict('os.environ', {'LOGSEQ_API_TOKEN': 'test_token'})
+    @patch('mcp_logseq.tools.logseq.LogSeq')
+    def test_run_tool_none_page_entity_no_crash(self, mock_logseq_class):
+        """Regression test for #45: None page_info in DB-mode results must not crash.
+
+        Logseq DB mode can return [None, [blocks]] as an item in the linked
+        references list.  The handler must silently skip such items and still
+        return results for valid items.
+        """
+        mock_api = Mock()
+        mock_api.get_page_linked_references.return_value = [
+            # DB-mode can produce a None where the page entity should be
+            [None, [{"content": "orphan block content"}]],
+            # A valid item that must still appear in the output
+            [
+                {"originalName": "ValidPage"},
+                [{"content": "Valid reference content"}],
+            ],
+        ]
+        mock_logseq_class.return_value = mock_api
+
+        handler = GetPageBacklinksToolHandler()
+        # Must not raise AttributeError / TypeError
+        result = handler.run_tool({"page_name": "TargetPage"})
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        text = result[0].text
+        # Valid item must be present
+        assert "ValidPage" in text
+        # None item must be silently skipped (no traceback, no crash)
+
+    @patch.dict('os.environ', {'LOGSEQ_API_TOKEN': 'test_token'})
     def test_run_tool_missing_args(self):
         """Test tool with missing page_name argument."""
         handler = GetPageBacklinksToolHandler()


### PR DESCRIPTION
Fixes #45.

`logseq.Editor.getPageLinkedReferences` can return items whose page entity is None (for example unresolvable source pages in DB mode). The existing guard only validated the outer list shape, so `page_info.get()` raised AttributeError and `get_page_backlinks` failed on any page with such a reference. This adds a type guard that skips those items, plus a regression test covering a None page entity alongside a valid one.