### PR TITLE
fix: prevent Python repr in block property serialization

### DIFF
--- a/src/mcp_logseq/parser.py
+++ b/src/mcp_logseq/parser.py
@@ -16,6 +16,20 @@ import yaml
 logger = logging.getLogger("mcp-logseq")
 
 
+def _format_block_prop_value(value: Any) -> str:
+    """
+    Serialize a block property value for Logseq's ``key:: value`` inline syntax.
+
+    Python lists are converted to Logseq's comma-separated convention
+    (e.g. ``["a", "b"]`` → ``"a, b"``), preventing the Python repr
+    notation ``['a', 'b']`` from leaking into the markdown file.
+    All other values are converted with ``str()``.
+    """
+    if isinstance(value, list):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
 @dataclass
 class BlockNode:
     """Represents a Logseq block with potential children."""
@@ -29,7 +43,7 @@ class BlockNode:
         """Convert to Logseq IBatchBlock format."""
         content = self.content
         if self.properties:
-            prop_lines = [f"{k}:: {v}" for k, v in self.properties.items()]
+            prop_lines = [f"{k}:: {_format_block_prop_value(v)}" for k, v in self.properties.items()]
             content = content + "\n" + "\n".join(prop_lines)
 
         result: dict[str, Any] = {"content": content}

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -658,6 +658,37 @@ class TestBlocksToBatchFormat:
         assert result[0]["content"] == "Block with props\npriority:: high"
         assert "properties" not in result[0]
 
+    def test_list_property_uses_comma_separated_not_python_repr(self):
+        """List-valued block properties must NOT produce Python repr like ['tag']."""
+        node = BlockNode(content="block", properties={"tags": ["mcp-test", "other"]})
+        fmt = node.to_batch_format()
+        # Must be comma-separated Logseq format
+        assert fmt["content"] == "block\ntags:: mcp-test, other"
+        # Must NOT contain Python single-quote list repr
+        assert "['mcp-test'" not in fmt["content"]
+        assert "['mcp-test', 'other']" not in fmt["content"]
+
+    def test_single_item_list_property_no_brackets(self):
+        """Single-item list should serialize as plain value without list syntax."""
+        node = BlockNode(content="block", properties={"tags": ["mcp-test"]})
+        fmt = node.to_batch_format()
+        assert fmt["content"] == "block\ntags:: mcp-test"
+        # Must NOT be Python repr ['mcp-test']
+        assert "['mcp-test']" not in fmt["content"]
+
+    def test_string_property_unchanged_by_fix(self):
+        """String block properties (existing behaviour) are unaffected."""
+        node = BlockNode(content="item", properties={"logseq.order-list-type": "number"})
+        fmt = node.to_batch_format()
+        assert fmt["content"] == "item\nlogseq.order-list-type:: number"
+
+    def test_empty_list_property(self):
+        """Empty list property serializes as empty string (not '[]')."""
+        node = BlockNode(content="block", properties={"tags": []})
+        fmt = node.to_batch_format()
+        assert fmt["content"] == "block\ntags:: "
+        assert "[]" not in fmt["content"]
+
 
 class TestParseContent:
     """Tests for the main parse_content entry point."""


### PR DESCRIPTION
Addresses the secondary bug reported in #48 (the primary symptom is upstream Logseq behavior, tracked in #51).

`BlockNode.to_batch_format()` built property lines with a bare f-string, which calls `str()` on list values and produces Python repr like `tags:: ['mcp-test']`. This was the only code path that could produce that output; the JSON based property write paths already serialize lists correctly. The fix adds a `_format_block_prop_value()` helper that renders lists as comma separated values (`tags:: foo, bar`) and keeps every other value type unchanged. Four new parser tests cover multi item lists, single item lists, plain strings, and empty lists.