### PR TITLE
fix: run tool handlers off the event loop to unblock vector tools

### DIFF
--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import sys
@@ -150,7 +151,7 @@ async def call_tool(
 
     try:
         logger.debug(f"Running tool {name}")
-        result = tool_handler.run_tool(arguments)
+        result = await asyncio.to_thread(tool_handler.run_tool, arguments)
         logger.debug(f"Tool result: {result}")
         return result
     except Exception as e:

--- a/src/mcp_logseq/vector/db.py
+++ b/src/mcp_logseq/vector/db.py
@@ -237,9 +237,12 @@ class VectorDB:
 
     def get_stats(self) -> dict:
         try:
+            import pyarrow.compute as pc
+
             total = self._table.count_rows()
-            pages_result = self._table.search().select(["page"]).to_list()
-            unique_pages = len({r["page"] for r in pages_result})
+            # Fetch only the page column via Arrow (no Python dict conversion per row)
+            pages_arrow = self._table.search().select(["page"]).to_arrow()
+            unique_pages = pc.count_distinct(pages_arrow.column("page")).as_py()
             return {"total_chunks": total, "total_pages": unique_pages}
         except Exception as e:
             logger.warning(f"Could not get stats: {e}")

--- a/src/mcp_logseq/vector/db.py
+++ b/src/mcp_logseq/vector/db.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -175,6 +176,7 @@ class VectorDB:
             return []
 
         top_k = params.top_k
+        logger.debug(f"search: mode={params.mode} top_k={top_k} filter_page={params.filter_page!r} filter_tags={params.filter_tags!r}")
 
         try:
             if params.mode == "keyword":
@@ -208,7 +210,10 @@ class VectorDB:
         where = self._build_filter(params)
         if where:
             q = q.where(where)
+        logger.debug("_vector_search: to_list start")
+        _t0 = time.perf_counter()
         rows = q.to_list()
+        logger.debug(f"_vector_search: to_list done in {(time.perf_counter() - _t0) * 1000:.1f}ms, {len(rows)} rows")
         return [_row_to_result(r, r.get("_distance", 0.0)) for r in rows]
 
     def _keyword_search(self, params: SearchParams, top_k: int) -> list[SearchResult]:
@@ -216,7 +221,10 @@ class VectorDB:
         where = self._build_filter(params)
         if where:
             q = q.where(where)
+        logger.debug("_keyword_search: to_list start")
+        _t0 = time.perf_counter()
         rows = q.to_list()
+        logger.debug(f"_keyword_search: to_list done in {(time.perf_counter() - _t0) * 1000:.1f}ms, {len(rows)} rows")
         return [_row_to_result(r, r.get("_score", 0.0)) for r in rows]
 
     def _hybrid_search(self, params: SearchParams, top_k: int) -> list[SearchResult]:
@@ -232,17 +240,24 @@ class VectorDB:
         where = self._build_filter(params)
         if where:
             q = q.where(where)
+        logger.debug("_hybrid_search: to_list start")
+        _t0 = time.perf_counter()
         rows = q.to_list()
+        logger.debug(f"_hybrid_search: to_list done in {(time.perf_counter() - _t0) * 1000:.1f}ms, {len(rows)} rows")
         return [_row_to_result(r, r.get("_relevance_score", 0.0)) for r in rows]
 
     def get_stats(self) -> dict:
         try:
             import pyarrow.compute as pc
 
+            _t0 = time.perf_counter()
             total = self._table.count_rows()
+            logger.debug(f"get_stats: count_rows={total} in {(time.perf_counter() - _t0) * 1000:.1f}ms")
             # Fetch only the page column via Arrow (no Python dict conversion per row)
+            _t1 = time.perf_counter()
             pages_arrow = self._table.search().select(["page"]).to_arrow()
             unique_pages = pc.count_distinct(pages_arrow.column("page")).as_py()
+            logger.debug(f"get_stats: unique_pages={unique_pages} in {(time.perf_counter() - _t1) * 1000:.1f}ms")
             return {"total_chunks": total, "total_pages": unique_pages}
         except Exception as e:
             logger.warning(f"Could not get stats: {e}")

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -14,6 +14,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from mcp.types import TextContent, Tool
@@ -172,15 +173,21 @@ class VectorSearchToolHandler(ToolHandler):
             logger.warning(f"Staleness check failed: {e}")
 
         try:
+            logger.debug(f"vector_search: embedding start (embedder={meta.embedder_key})")
+            _t_emb = time.perf_counter()
             embedder = create_embedder(self._config.embedder)
             query_vector = embedder.embed([query])[0]
+            logger.debug(f"vector_search: embedding done in {(time.perf_counter() - _t_emb) * 1000:.1f}ms")
         except RuntimeError as e:
             return [TextContent(type="text", text=str(e))]
         except Exception as e:
             return [TextContent(type="text", text=f"Embedding failed: {e}")]
 
         try:
+            logger.debug(f"vector_search: opening table at {self._config.db_path}")
+            _t_open = time.perf_counter()
             db = VectorDB.open_readonly(self._config.db_path, meta.dimensions)
+            logger.debug(f"vector_search: table opened in {(time.perf_counter() - _t_open) * 1000:.1f}ms")
         except RuntimeError as e:
             return [TextContent(type="text", text=str(e))]
         except Exception as e:
@@ -196,7 +203,10 @@ class VectorSearchToolHandler(ToolHandler):
         )
 
         try:
+            logger.debug(f"vector_search: query start (mode={search_mode})")
+            _t_q = time.perf_counter()
             results = db.search(params)
+            logger.debug(f"vector_search: query done in {(time.perf_counter() - _t_q) * 1000:.1f}ms, {len(results)} results")
         except Exception as e:
             return [TextContent(type="text", text=f"Search failed: {e}")]
         finally:
@@ -281,8 +291,13 @@ class VectorDBStatusToolHandler(ToolHandler):
             )]
 
         try:
+            logger.debug(f"vector_db_status: opening table at {self._config.db_path}")
+            _t_open = time.perf_counter()
             db = VectorDB.open_readonly(self._config.db_path, meta.dimensions)
+            logger.debug(f"vector_db_status: table opened in {(time.perf_counter() - _t_open) * 1000:.1f}ms")
+            _t_stats = time.perf_counter()
             stats = db.get_stats()
+            logger.debug(f"vector_db_status: get_stats done in {(time.perf_counter() - _t_stats) * 1000:.1f}ms")
             db.close()
         except RuntimeError as e:
             # open_readonly gives clear diagnostics (version mismatch, not initialized)

--- a/tests/unit/vector/test_asyncio_regression.py
+++ b/tests/unit/vector/test_asyncio_regression.py
@@ -1,0 +1,201 @@
+"""
+Regression tests for asyncio/LanceDB deadlock (issue #44).
+
+Root cause: all ToolHandler.run_tool() implementations are synchronous. Before the
+fix, server.py called run_tool() directly in the async event loop, blocking it
+entirely. LanceDB's Rust/Arrow layer also caused event-loop contention on Windows
+(the to_list() hang could not be reproduced on macOS).
+
+Fix applied: server.py call_tool() now uses ``await asyncio.to_thread(...)`` to
+offload all synchronous handler work to a thread pool.
+
+These tests use a real (tiny) LanceDB table and a stub embedder to prove:
+  1. VectorDB.get_stats() returns correct page counts after the Arrow-based
+     efficiency fix (no more full Python dict conversion per row).
+  2. VectorSearchToolHandler.run_tool() completes when dispatched through
+     asyncio.to_thread() — i.e. no deadlock even with a live asyncio event loop.
+  3. VectorDBStatusToolHandler.run_tool() likewise completes via asyncio.to_thread().
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from mcp_logseq.vector.db import VectorDB
+from mcp_logseq.vector.types import LogseqChunk
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_DIMS = 4
+_EMBEDDER_KEY = "stub/test-4d"
+
+
+def _make_chunk(page: str, idx: int, vec: list[float]) -> LogseqChunk:
+    return LogseqChunk(
+        id=f"{page}::{idx}",
+        page=page,
+        text=f"content of {page} block {idx}",
+        raw=f"raw content {idx}",
+        tags=[],
+        date=None,
+        properties="{}",
+        block_index=idx,
+        vector=vec,
+    )
+
+
+@pytest.fixture
+def tiny_db(tmp_path):
+    """Real LanceDB with 3 chunks across 2 pages, plus a sync-meta.json file."""
+    db_path = str(tmp_path / "vector_db")
+
+    db = VectorDB.open(db_path, _DIMS)
+    chunks = [
+        _make_chunk("Page A", 0, [0.1, 0.2, 0.3, 0.4]),
+        _make_chunk("Page A", 1, [0.2, 0.3, 0.4, 0.5]),
+        _make_chunk("Page B", 0, [0.3, 0.4, 0.5, 0.6]),
+    ]
+    db.upsert(chunks)
+    db.close()
+
+    (tmp_path / "vector_db" / "sync-meta.json").write_text(
+        json.dumps(
+            {
+                "embedder_key": _EMBEDDER_KEY,
+                "dimensions": _DIMS,
+                "last_full_sync": "2024-01-01T00:00:00+00:00",
+            }
+        )
+    )
+    return db_path
+
+
+def _stub_embedder():
+    """Return a MagicMock embedder that returns a fixed 4-d vector."""
+    from unittest.mock import MagicMock
+
+    emb = MagicMock()
+    emb.key = _EMBEDDER_KEY
+    emb.dimensions = _DIMS
+    emb.embed.return_value = [[0.1, 0.2, 0.3, 0.4]]
+    return emb
+
+
+# ---------------------------------------------------------------------------
+# 1. get_stats efficiency fix
+# ---------------------------------------------------------------------------
+
+
+class TestGetStats:
+    """VectorDB.get_stats() uses Arrow column projection — correct counts, no full scan."""
+
+    def test_returns_correct_chunk_count(self, tiny_db):
+        db = VectorDB.open_readonly(tiny_db, _DIMS)
+        stats = db.get_stats()
+        db.close()
+        assert stats["total_chunks"] == 3
+
+    def test_returns_correct_unique_page_count(self, tiny_db):
+        db = VectorDB.open_readonly(tiny_db, _DIMS)
+        stats = db.get_stats()
+        db.close()
+        # 3 chunks spread across Page A (2) and Page B (1)
+        assert stats["total_pages"] == 2
+
+    def test_returns_zero_for_empty_table(self, tmp_path):
+        db_path = str(tmp_path / "empty_db")
+        db = VectorDB.open(db_path, _DIMS)
+        stats = db.get_stats()
+        db.close()
+        assert stats["total_chunks"] == 0
+        assert stats["total_pages"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. asyncio.to_thread regression — VectorSearchToolHandler
+# ---------------------------------------------------------------------------
+
+
+class TestVectorSearchViaToThread:
+    """VectorSearchToolHandler.run_tool() must complete when called via asyncio.to_thread()."""
+
+    def test_completes_via_to_thread_no_deadlock(self, tiny_db, tmp_path):
+        """Regression: run_tool must not deadlock when dispatched via asyncio.to_thread()."""
+        from unittest.mock import MagicMock, patch
+
+        from mcp_logseq.vector.index import VectorSearchToolHandler
+
+        config = MagicMock()
+        config.db_path = tiny_db
+        config.graph_path = str(tmp_path / "graph")  # non-existent → staleness skips cleanly
+        config.embedder = MagicMock()
+        handler = VectorSearchToolHandler(config)
+
+        stub = _stub_embedder()
+
+        async def _run():
+            with patch("mcp_logseq.vector.index.create_embedder", return_value=stub):
+                return await asyncio.to_thread(handler.run_tool, {"query": "hello"})
+
+        results = asyncio.run(_run())
+        assert results, "handler returned no TextContent"
+        assert results[0].text  # non-empty output
+
+    def test_returns_search_results_via_to_thread(self, tiny_db, tmp_path):
+        """Results from a real LanceDB table are returned correctly through the thread boundary."""
+        from unittest.mock import MagicMock, patch
+
+        from mcp_logseq.vector.index import VectorSearchToolHandler
+
+        config = MagicMock()
+        config.db_path = tiny_db
+        config.graph_path = str(tmp_path / "graph")
+        config.embedder = MagicMock()
+        handler = VectorSearchToolHandler(config)
+
+        stub = _stub_embedder()
+
+        async def _run():
+            with patch("mcp_logseq.vector.index.create_embedder", return_value=stub):
+                return await asyncio.to_thread(
+                    handler.run_tool, {"query": "content", "top_k": 3}
+                )
+
+        results = asyncio.run(_run())
+        text = results[0].text
+        # At least one of our page titles should appear in results
+        assert "Page A" in text or "Page B" in text
+
+
+# ---------------------------------------------------------------------------
+# 3. asyncio.to_thread regression — VectorDBStatusToolHandler
+# ---------------------------------------------------------------------------
+
+
+class TestVectorDBStatusViaToThread:
+    """VectorDBStatusToolHandler.run_tool() must complete via asyncio.to_thread()."""
+
+    def test_completes_via_to_thread_no_deadlock(self, tiny_db):
+        """Regression: status handler must not block or deadlock via asyncio.to_thread()."""
+        from unittest.mock import MagicMock, patch
+
+        from mcp_logseq.vector.index import VectorDBStatusToolHandler
+
+        config = MagicMock()
+        config.db_path = tiny_db
+        config.graph_path = "/nonexistent/graph"
+        handler = VectorDBStatusToolHandler(config)
+
+        async def _run():
+            return await asyncio.to_thread(handler.run_tool, {})
+
+        results = asyncio.run(_run())
+        assert results
+        text = results[0].text
+        assert "Vector DB Status" in text
+        assert "3" in text  # total_chunks
+        assert "2" in text  # total_pages


### PR DESCRIPTION
Fixes #44.

Root cause was exactly as diagnosed in the issue: every `ToolHandler.run_tool()` is synchronous and was called directly inside the async `call_tool` handler, blocking the event loop. LanceDB's internal tokio runtime then deadlocked against it, so vector tools hung forever via MCP while working fine from plain Python.

Changes:
- `server.py` wraps the handler call in `await asyncio.to_thread(...)` so the event loop stays free. This benefits all tools, not just the vector ones.
- `VectorDB.get_stats()` no longer materializes every row to count unique pages; it projects the page column to Arrow and uses `count_distinct`.
- New regression tests build a real (tiny) LanceDB table with a stub embedder and prove the vector handlers complete when dispatched from a running event loop.
- Debug level timing logs around every LanceDB `to_list()` call and handler stage, so if the hang ever reappears the last line in `mcp_logseq.log` identifies the stalled stage.

Note: the deeper Windows hang reported in the issue comments could not be reproduced on macOS. The `to_thread` fix removes the runtime contention my analysis points to, but Windows verification is pending; the new debug logs are there to pinpoint it quickly if it persists.