### PR TITLE
chore: bump version to 1.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-logseq"
-version = "1.6.2"
+version = "1.6.3"
 description = "MCP server to work with LogSeq via the local HTTP server"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Version bump for the 1.6.3 release: #52, #53, #54, #50.