### PR TITLE
feat: add format=json to query and search tools (closes #43)

### DIFF
--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -860,6 +860,12 @@ class SearchToolHandler(ToolHandler):
                         "description": "Include file name results",
                         "default": False,
                     },
+                    "format": {
+                        "type": "string",
+                        "description": "Output format (text or json). JSON includes block UUIDs and page identifiers for deep linking.",
+                        "enum": ["text", "json"],
+                        "default": "text",
+                    },
                 },
                 "required": ["query"],
             },
@@ -1016,6 +1022,61 @@ class SearchToolHandler(ToolHandler):
         parts.append(f"\n**Total results found: {total}**")
         return parts
 
+    @staticmethod
+    def _build_json_results(
+        result: dict, query: str, limit: int,
+        include_blocks: bool, include_pages: bool, include_files: bool,
+        excluded_page_names: set[str] = frozenset(),
+    ) -> dict:
+        """Build structured search results with UUIDs and page identifiers.
+
+        Applies the same exclusion filtering, include flags, and limit as the
+        text formatters, but preserves the raw fields (uuid, page) so callers
+        can build logseq:// deep links without follow-up calls.
+        """
+        out: dict = {"query": query, "mode": "db" if _db_mode else "markdown"}
+
+        if _db_mode:
+            blocks = result.get("blocks", [])
+            if include_pages:
+                out["pages"] = [
+                    p for p in blocks
+                    if p.get("page?")
+                    and (p.get("fullTitle") or p.get("title") or p.get("content", "")).lower()
+                    not in excluded_page_names
+                ]
+            if include_blocks:
+                block_results = []
+                for block in [b for b in blocks if not b.get("page?")][:limit]:
+                    block = dict(block)
+                    content = block.get("content", "")
+                    block["content"] = content.replace("$pfts_2lqh>$", "").replace(
+                        "$<pfts_2lqh$", ""
+                    )
+                    block_results.append(block)
+                out["blocks"] = block_results
+            if include_files:
+                out["files"] = result.get("files", [])
+            out["has_more"] = bool(result.get("hasMore?"))
+        else:
+            if include_blocks:
+                out["blocks"] = result.get("blocks", [])[:limit]
+            if include_pages:
+                out["pages"] = [
+                    p for p in result.get("pages", [])
+                    if p.lower() not in excluded_page_names
+                ]
+                if not excluded_page_names:
+                    # Snippets carry no page identifier, so they cannot be
+                    # exclusion-filtered — only expose them when no exclusion
+                    # is active (same rule as text mode)
+                    out["pages_content"] = result.get("pages-content", [])[:limit]
+            if include_files:
+                out["files"] = result.get("files", [])
+            out["has_more"] = bool(result.get("has-more?"))
+
+        return out
+
     def run_tool(self, args: dict) -> list[TextContent]:
         """Execute search and format results."""
         logger.info(f"Searching with args: {args}")
@@ -1045,6 +1106,12 @@ class SearchToolHandler(ToolHandler):
 
             # Build excluded page name set (one extra API call only when needed)
             excluded_page_names = self._build_excluded_page_names(api, _exclude_tags)
+
+            if args.get("format") == "json":
+                json_result = self._build_json_results(
+                    result, query, limit, include_blocks, include_pages, include_files, excluded_page_names
+                )
+                return [TextContent(type="text", text=json.dumps(json_result, indent=2))]
 
             # Format results
             content_parts = []
@@ -1098,6 +1165,12 @@ class QueryToolHandler(ToolHandler):
                         "description": "Filter results by type",
                         "enum": ["all", "pages_only", "blocks_only"],
                         "default": "all"
+                    },
+                    "format": {
+                        "type": "string",
+                        "description": "Output format (text or json). JSON returns raw result objects including block UUIDs and page info for deep linking.",
+                        "enum": ["text", "json"],
+                        "default": "text"
                     }
                 },
                 "required": ["query"]
@@ -1189,6 +1262,14 @@ class QueryToolHandler(ToolHandler):
 
             # Apply limit
             limited_results = filtered_results[:limit]
+
+            if args.get("format") == "json":
+                json_result = {
+                    "query": query,
+                    "total": len(filtered_results),
+                    "results": limited_results,
+                }
+                return [TextContent(type="text", text=json.dumps(json_result, indent=2))]
 
             # Format results
             content_parts = []

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest.mock import patch, Mock
 from mcp.types import TextContent
@@ -885,6 +887,86 @@ class TestSearchToolHandler:
         assert "block-uuid" in text
         assert "Total results found: 2" in text
 
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_run_tool_json_format_markdown_mode(self, mock_logseq_class):
+        """Test JSON format preserves block UUIDs in markdown mode."""
+        mock_api = Mock()
+        mock_api.search_content.return_value = {
+            "blocks": [
+                {"block/content": "TODO task one", "block/uuid": "uuid-1", "block/page": 42},
+            ],
+            "pages": ["Project Page"],
+            "pages-content": [{"block/snippet": "Snippet content"}],
+            "files": [],
+            "has-more?": False,
+        }
+        mock_logseq_class.return_value = mock_api
+
+        handler = SearchToolHandler()
+        result = handler.run_tool({"query": "TODO", "format": "json"})
+
+        data = json.loads(result[0].text)
+        assert data["query"] == "TODO"
+        assert data["mode"] == "markdown"
+        assert data["blocks"][0]["block/uuid"] == "uuid-1"
+        assert data["pages"] == ["Project Page"]
+        assert data["pages_content"][0]["block/snippet"] == "Snippet content"
+        assert data["has_more"] is False
+
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_run_tool_json_format_db_mode(self, mock_logseq_class):
+        """Test JSON format preserves UUIDs and page refs in DB mode."""
+        mock_api = Mock()
+        mock_api.search_content.return_value = {
+            "blocks": [
+                {"page?": True, "fullTitle": "Some Page", "uuid": "page-uuid",
+                 "content": "Some Page", "page": "page-uuid"},
+                {"page?": False, "content": "$pfts_2lqh>$match$<pfts_2lqh$ text",
+                 "uuid": "block-uuid", "page": "parent-page-uuid"},
+            ],
+            "hasMore?": True,
+        }
+        mock_logseq_class.return_value = mock_api
+
+        handler = SearchToolHandler()
+        with patch("mcp_logseq.tools._db_mode", True):
+            result = handler.run_tool({"query": "match", "format": "json"})
+
+        data = json.loads(result[0].text)
+        assert data["mode"] == "db"
+        assert data["pages"][0]["uuid"] == "page-uuid"
+        assert data["blocks"][0]["uuid"] == "block-uuid"
+        assert data["blocks"][0]["page"] == "parent-page-uuid"
+        assert data["blocks"][0]["content"] == "match text"
+        assert data["has_more"] is True
+
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_run_tool_json_format_respects_exclusions(self, mock_logseq_class):
+        """Test JSON format filters excluded pages and hides snippets."""
+        mock_api = Mock()
+        mock_api.search_content.return_value = {
+            "blocks": [],
+            "pages": ["Secret Page", "Public Page"],
+            "pages-content": [{"block/snippet": "secret snippet"}],
+            "files": [],
+            "has-more?": False,
+        }
+        mock_api.list_pages.return_value = [
+            {"originalName": "Secret Page", "properties": {"tags": ["private"]}},
+        ]
+        mock_logseq_class.return_value = mock_api
+
+        handler = SearchToolHandler()
+        with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+            result = handler.run_tool({"query": "secret", "format": "json"})
+
+        data = json.loads(result[0].text)
+        assert data["pages"] == ["Public Page"]
+        assert "pages_content" not in data
+
 
 class TestQueryToolHandler:
     """Test cases for QueryToolHandler."""
@@ -1017,6 +1099,49 @@ class TestQueryToolHandler:
 
         with pytest.raises(RuntimeError, match="query argument required"):
             handler.run_tool({})
+
+    @patch.dict('os.environ', {'LOGSEQ_API_TOKEN': 'test_token'})
+    @patch('mcp_logseq.tools.logseq.LogSeq')
+    def test_run_tool_json_format(self, mock_logseq_class):
+        """Test JSON format returns raw items with UUIDs and page info."""
+        mock_api = Mock()
+        mock_api.query_dsl.return_value = [
+            {"content": "TODO write docs", "uuid": "block-uuid-1",
+             "page": {"id": 7, "name": "project", "originalName": "Project"}},
+        ]
+        mock_logseq_class.return_value = mock_api
+
+        handler = QueryToolHandler()
+        result = handler.run_tool({"query": "(task TODO)", "format": "json"})
+
+        data = json.loads(result[0].text)
+        assert data["query"] == "(task TODO)"
+        assert data["total"] == 1
+        assert data["results"][0]["uuid"] == "block-uuid-1"
+        assert data["results"][0]["page"]["originalName"] == "Project"
+
+    @patch.dict('os.environ', {'LOGSEQ_API_TOKEN': 'test_token'})
+    @patch('mcp_logseq.tools.logseq.LogSeq')
+    def test_run_tool_json_format_applies_limit_and_filters(self, mock_logseq_class):
+        """Test JSON format respects limit and result_type filtering."""
+        mock_api = Mock()
+        mock_api.query_dsl.return_value = [
+            {"originalName": "Page A"},
+            {"content": "Block one", "uuid": "u1"},
+            {"content": "Block two", "uuid": "u2"},
+        ]
+        mock_logseq_class.return_value = mock_api
+
+        handler = QueryToolHandler()
+        result = handler.run_tool({
+            "query": "(task TODO)", "format": "json",
+            "result_type": "blocks_only", "limit": 1,
+        })
+
+        data = json.loads(result[0].text)
+        assert data["total"] == 2
+        assert len(data["results"]) == 1
+        assert data["results"][0]["uuid"] == "u1"
 
 
 class TestFindPagesByPropertyToolHandler:


### PR DESCRIPTION
This adds a `format` parameter (`text` or `json`, default `text`) to the `query` and `search` tools, following the same pattern `get_page_content` already uses.

With `format=json`:
- `query` returns the raw result objects, including block `uuid` and the page entity with `originalName`, so you can build `logseq://graph/<name>?block-id=<uuid>` links directly.
- `search` returns structured results with UUIDs and page identifiers preserved, in both DB mode and markdown mode. The same `exclude_tags` filtering, include flags, and result limits apply as in text mode.

Default text output is unchanged, so existing consumers are unaffected.

Closes #43