### PR TITLE
fix: make create_page fail on existing pages instead of duplicating

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ def hello():
 - **`append`** (default): Add new content after existing blocks
 - **`replace`**: Clear page and replace with new content
 
+### 🔁 Safe Retries & Large Writes
+
+`create_page` fails with a clear error if a page with the same title already exists, instead of letting Logseq silently create numbered duplicates (`Page(1)`, `Page 2`, ...). This makes retries after a timeout safe: if a previous `create_page` call timed out but actually committed, the retry tells you the page exists rather than fragmenting your content across ghost pages.
+
+For large writes, prefer this pattern over one giant `create_page` call:
+
+1. Create the page with little or no content (`create_page` with just the title and properties)
+2. Append content in smaller chunks with `update_page` (`mode: append`)
+3. Read back with `get_page_content` to verify the result
+
+If you hit the "already exists" error mid-ingest, use `get_page_content` to see what landed, then continue with `update_page` instead of re-creating.
+
 ---
 
 ## ⚙️ Prerequisites

--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -67,6 +67,25 @@ class LogSeq:
             logger.error(f"Error creating page: {str(e)}")
             raise
 
+    def page_exists(self, page_name: str) -> bool:
+        """Check whether a page with the given name already exists."""
+        url = self.get_base_url()
+
+        try:
+            response = requests.post(
+                url,
+                headers=self._get_headers(),
+                json={"method": "logseq.Editor.getPage", "args": [page_name]},
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json() is not None
+
+        except Exception as e:
+            logger.error(f"Error checking if page exists: {str(e)}")
+            raise
+
     def list_pages(self) -> Any:
         """List all pages in the LogSeq graph."""
         url = self.get_base_url()

--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -80,7 +80,9 @@ class LogSeq:
                 timeout=self.timeout,
             )
             response.raise_for_status()
-            return response.json() is not None
+            # Treat any falsy payload (null, {}) as "missing", matching
+            # get_page_content's defensive check on getPage responses.
+            return bool(response.json())
 
         except Exception as e:
             logger.error(f"Error checking if page exists: {str(e)}")
@@ -366,6 +368,12 @@ class LogSeq:
         """
         url = self.get_base_url()
         logger.info(f"Creating page '{title}' with {len(blocks)} blocks")
+
+        # Guard against duplicates at the write layer: Logseq auto-numbers
+        # pages with an existing name ("Page(1)", "Page 2"), which silently
+        # fragments content when a timed-out create is retried (issue #58).
+        if self.page_exists(title):
+            raise ValueError(f"Page '{title}' already exists")
 
         try:
             # Normalize properties for the createPage API.

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -126,6 +126,10 @@ class CreatePageToolHandler(ToolHandler):
             name=self.name,
             description="""Create a new page in Logseq with properly structured blocks.
 
+Fails if a page with the same title already exists (use update_page to modify
+existing pages). This makes retries safe: re-sending a create_page that timed
+out will not create numbered duplicates like "Page(1)".
+
 Markdown content is automatically parsed into Logseq's block hierarchy:
 - Headings (# ## ###) create nested sections
 - Lists (- or 1.) become proper block trees  
@@ -175,6 +179,17 @@ Introduction paragraph.
 
         try:
             api = _make_api()
+
+            # Refuse to create a duplicate: Logseq auto-numbers pages with an
+            # existing name ("Page(1)", "Page 2"), which silently fragments
+            # content when a timed-out create_page is retried (issue #58).
+            if api.page_exists(title):
+                raise RuntimeError(
+                    f"Page '{title}' already exists. Use update_page to modify "
+                    "it (mode='append' or mode='replace'), or get_page_content "
+                    "to inspect it. If a previous create_page call timed out, "
+                    "the page may already contain the content you sent."
+                )
 
             # Parse the content
             parsed = (

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -184,7 +184,7 @@ Introduction paragraph.
             # existing name ("Page(1)", "Page 2"), which silently fragments
             # content when a timed-out create_page is retried (issue #58).
             if api.page_exists(title):
-                raise RuntimeError(
+                raise ValueError(
                     f"Page '{title}' already exists. Use update_page to modify "
                     "it (mode='append' or mode='replace'), or get_page_content "
                     "to inspect it. If a previous create_page call timed out, "

--- a/tests/integration/test_mcp_server.py
+++ b/tests/integration/test_mcp_server.py
@@ -78,6 +78,7 @@ class TestMCPServerIntegration:
         """Test successful tool call execution through handler."""
         # Setup mock
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_logseq_class.return_value = mock_api
 
         # Test create_page tool directly through handler (new version)
@@ -105,6 +106,7 @@ class TestMCPServerIntegration:
         """Test tool call when handler raises an exception."""
         # Setup mock to raise exception (new handler uses create_page_with_blocks)
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_api.create_page_with_blocks.side_effect = Exception("API Error")
         mock_logseq_class.return_value = mock_api
 

--- a/tests/unit/test_logseq_api.py
+++ b/tests/unit/test_logseq_api.py
@@ -132,6 +132,35 @@ class TestLogSeqAPI:
         assert request_data["args"] == ["Test Page"]
 
     @responses.activate
+    def test_page_exists_false_on_empty_dict(self, logseq_client):
+        """page_exists treats non-null falsy responses (e.g. {}) as missing."""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:12315/api",
+            json={},
+            status=200,
+        )
+
+        assert logseq_client.page_exists("Nope") is False
+
+    @responses.activate
+    def test_create_page_with_blocks_rejects_existing_page(self, logseq_client):
+        """create_page_with_blocks itself guards against duplicating a page."""
+        # getPage returns an existing entity
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:12315/api",
+            json={"name": "test page", "uuid": "abc"},
+            status=200,
+        )
+
+        with pytest.raises(ValueError, match="already exists"):
+            logseq_client.create_page_with_blocks("Test Page", [{"content": "x"}])
+
+        # Only the existence check ran — no createPage call was made
+        assert len(responses.calls) == 1
+
+    @responses.activate
     def test_page_exists_false(self, logseq_client):
         """page_exists returns False when getPage returns null."""
         responses.add(

--- a/tests/unit/test_logseq_api.py
+++ b/tests/unit/test_logseq_api.py
@@ -114,6 +114,37 @@ class TestLogSeqAPI:
             logseq_client.create_page("Test Page", "")
 
     @responses.activate
+    def test_page_exists_true(self, logseq_client):
+        """page_exists returns True when getPage returns a page entity."""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:12315/api",
+            json={"name": "test page", "originalName": "Test Page", "uuid": "abc"},
+            status=200,
+        )
+
+        assert logseq_client.page_exists("Test Page") is True
+
+        body = responses.calls[0].request.body
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["method"] == "logseq.Editor.getPage"
+        assert request_data["args"] == ["Test Page"]
+
+    @responses.activate
+    def test_page_exists_false(self, logseq_client):
+        """page_exists returns False when getPage returns null."""
+        responses.add(
+            responses.POST,
+            "http://127.0.0.1:12315/api",
+            body="null",
+            status=200,
+            content_type="application/json",
+        )
+
+        assert logseq_client.page_exists("Nope") is False
+
+    @responses.activate
     def test_list_pages_success(self, logseq_client, mock_logseq_responses):
         """Test successful page listing."""
         responses.add(

--- a/tests/unit/test_property_persistence.py
+++ b/tests/unit/test_property_persistence.py
@@ -17,6 +17,7 @@ class TestCreatePageProperties:
     def _add_create_mocks(self, page_json=None, with_remove=True):
         """Register HTTP mocks for a create_page_with_blocks call with blocks."""
         url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, body="null", status=200, content_type="application/json")  # getPage existence check
         responses.add(responses.POST, url, json=page_json or {"uuid": "page-uuid", "name": "Test Page"}, status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": ""}], status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-2"}], status=200)
@@ -33,7 +34,7 @@ class TestCreatePageProperties:
         logseq_client.create_page_with_blocks("Test Page", blocks, properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["method"] == "logseq.Editor.createPage"
         # Properties are in the 2nd arg — page entity level, not block level
         assert body["args"][1] == {"priority": "high", "status": "active"}
@@ -55,7 +56,7 @@ class TestCreatePageProperties:
         logseq_client.create_page_with_blocks("Test Page", blocks, properties=None)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["method"] == "logseq.Editor.createPage"
         assert body["args"][1] == {}  # empty dict when no properties
 
@@ -76,7 +77,7 @@ class TestCreatePageProperties:
         logseq_client.create_page_with_blocks("Test Page", blocks, properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["method"] == "logseq.Editor.createPage"
         assert body["args"][1]["tags"] == ["project", "urgent", "backend"]
 
@@ -287,6 +288,7 @@ class TestPropertyTypes:
     def _add_create_mocks(self):
         """Register the 4 HTTP mocks needed for a create_page_with_blocks call with blocks."""
         url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, body="null", status=200, content_type="application/json")  # getPage existence check
         responses.add(responses.POST, url, json={"uuid": "page-uuid"}, status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-1"}], status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-2"}], status=200)
@@ -301,7 +303,7 @@ class TestPropertyTypes:
         logseq_client.create_page_with_blocks("Test", [{"content": "Content"}], properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["args"][1] == {"title": "My Title", "author": "John Doe"}
 
     @responses.activate
@@ -313,7 +315,7 @@ class TestPropertyTypes:
         logseq_client.create_page_with_blocks("Test", [{"content": "Content"}], properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["args"][1]["priority"] == 5
         assert body["args"][1]["score"] == 9.5
 
@@ -326,7 +328,7 @@ class TestPropertyTypes:
         logseq_client.create_page_with_blocks("Test", [{"content": "Content"}], properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["args"][1]["metadata"] == {"author": "John", "date": "2024-01-01"}
 
 
@@ -451,6 +453,7 @@ class TestPropertyValueNormalization:
     def test_create_page_with_tags_dict_normalizes(self, logseq_client):
         """End-to-end: tags dict is normalized to an array in the createPage call."""
         url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, body="null", status=200, content_type="application/json")  # getPage existence check
         responses.add(responses.POST, url, json={"uuid": "page-uuid"}, status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-1"}], status=200)
         responses.add(responses.POST, url, json=[{"uuid": "block-2"}], status=200)
@@ -460,7 +463,7 @@ class TestPropertyValueNormalization:
         logseq_client.create_page_with_blocks("Test", [{"content": "Content"}], properties)
 
         import json
-        body = json.loads(responses.calls[0].request.body)
+        body = json.loads(responses.calls[1].request.body)
         assert body["method"] == "logseq.Editor.createPage"
         # Normalized to a list, not the raw dict
         assert isinstance(body["args"][1]["tags"], list)

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -46,6 +46,7 @@ class TestCreatePageToolHandler:
         """Test successful page creation with markdown content."""
         # Setup mock
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_logseq_class.return_value = mock_api
 
         handler = CreatePageToolHandler()
@@ -69,6 +70,7 @@ class TestCreatePageToolHandler:
     def test_run_tool_with_frontmatter(self, mock_logseq_class):
         """Test page creation with YAML frontmatter."""
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_logseq_class.return_value = mock_api
 
         handler = CreatePageToolHandler()
@@ -86,6 +88,7 @@ class TestCreatePageToolHandler:
     def test_run_tool_with_explicit_properties(self, mock_logseq_class):
         """Test page creation with explicit properties argument."""
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_logseq_class.return_value = mock_api
 
         handler = CreatePageToolHandler()
@@ -107,6 +110,7 @@ class TestCreatePageToolHandler:
     def test_run_tool_empty_page(self, mock_logseq_class):
         """Test creating empty page (title only)."""
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_logseq_class.return_value = mock_api
 
         handler = CreatePageToolHandler()
@@ -132,6 +136,7 @@ class TestCreatePageToolHandler:
     def test_run_tool_api_error(self, mock_logseq_class):
         """Test tool with API error."""
         mock_api = Mock()
+        mock_api.page_exists.return_value = False
         mock_api.create_page_with_blocks.side_effect = Exception("API Error")
         mock_logseq_class.return_value = mock_api
 
@@ -140,6 +145,35 @@ class TestCreatePageToolHandler:
 
         with pytest.raises(Exception, match="API Error"):
             handler.run_tool(args)
+
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_run_tool_existing_page_errors_without_creating(self, mock_logseq_class):
+        """create_page must not create a duplicate when the page already exists."""
+        mock_api = Mock()
+        mock_api.page_exists.return_value = True
+        mock_logseq_class.return_value = mock_api
+
+        handler = CreatePageToolHandler()
+        args = {"title": "Existing Page", "content": "# Some content"}
+
+        with pytest.raises(RuntimeError, match="already exists"):
+            handler.run_tool(args)
+
+        mock_api.create_page_with_blocks.assert_not_called()
+
+    @patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"})
+    @patch("mcp_logseq.tools.logseq.LogSeq")
+    def test_run_tool_existing_page_error_mentions_update_page(self, mock_logseq_class):
+        """The duplicate-page error should point the client at update_page."""
+        mock_api = Mock()
+        mock_api.page_exists.return_value = True
+        mock_logseq_class.return_value = mock_api
+
+        handler = CreatePageToolHandler()
+
+        with pytest.raises(RuntimeError, match="update_page"):
+            handler.run_tool({"title": "Existing Page"})
 
 
 class TestListPagesToolHandler:

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -157,7 +157,7 @@ class TestCreatePageToolHandler:
         handler = CreatePageToolHandler()
         args = {"title": "Existing Page", "content": "# Some content"}
 
-        with pytest.raises(RuntimeError, match="already exists"):
+        with pytest.raises(ValueError, match="already exists"):
             handler.run_tool(args)
 
         mock_api.create_page_with_blocks.assert_not_called()
@@ -172,7 +172,7 @@ class TestCreatePageToolHandler:
 
         handler = CreatePageToolHandler()
 
-        with pytest.raises(RuntimeError, match="update_page"):
+        with pytest.raises(ValueError, match="update_page"):
             handler.run_tool({"title": "Existing Page"})
 
 


### PR DESCRIPTION
Closes #58

## Problem

When a `create_page` call times out but Logseq has actually committed the write, a client retry creates a duplicate instead of converging on the existing page. Logseq auto numbers these (`Page(1)`, `Page 2`, ...), which in #46 fragmented a single ingest batch into 35 ghost pages.

## Fix

`create_page` now checks whether the page already exists before creating it. If it does, the tool returns a clear error that points the client at `update_page` (append/replace) and `get_page_content`, and notes that a timed out earlier call may have already committed the content. This makes retries safe by construction.

- New `LogSeq.page_exists()` using `logseq.Editor.getPage` (returns null for missing pages)
- Existence check in `CreatePageToolHandler.run_tool` before any write
- Tool description updated so MCP clients know retries won't duplicate
- README: new "Safe Retries & Large Writes" section documenting the chunked write pattern (create empty, append in chunks, read back) that @dave-walschot was already using as a workaround

## Tests

4 new tests (2 API level for `page_exists`, 2 handler level asserting the error fires, mentions `update_page`, and that no write happens). Existing create_page tests updated to stub `page_exists` as False. Full suite: 406 passed.