### PR TITLE
fix: make update_page properties graph-type aware

### DIFF
--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -14,12 +14,14 @@ class LogSeq:
         port: int = 12315,
         verify_ssl: bool = False,
         timeout: tuple[float, float] | None = None,
+        db_mode: bool = False,
     ):
         self.api_key = api_key
         self.protocol = protocol
         self.host = host
         self.port = port
         self.verify_ssl = verify_ssl
+        self.db_mode = db_mode
         self.timeout = timeout or (3, 6)
 
     def get_base_url(self) -> str:
@@ -538,16 +540,31 @@ class LogSeq:
                             self._append_block_recursive(page_name, block)
                         results.append(("blocks_appended", len(blocks)))
 
-            # Update properties AFTER blocks are inserted/replaced
+            # Update properties AFTER blocks are inserted/replaced.
+            #
+            # Property storage differs by graph type:
+            #   - DB graphs: properties live at the page entity level and must be
+            #     written via setPageProperties; block-level properties don't
+            #     register as page properties (invisible to (page-property ...)
+            #     queries and the page info panel).
+            #   - File graphs: page properties are the `key:: value` lines in the
+            #     first block, so upsertBlockProperty on that block is the native
+            #     representation and updates values in place.
             if properties:
                 if mode == "append":
                     existing_props = self._get_page_level_properties(page_name)
                     merged_props = {**existing_props, **properties}
-                    self._set_page_level_properties(page_name, merged_props)
+                    if self.db_mode:
+                        self._set_page_level_properties(page_name, merged_props)
+                    else:
+                        self._update_page_properties(page_name, properties)
                     results.append(("properties", merged_props))
                 else:
-                    # Replace mode - set only the new properties
-                    self._set_page_level_properties(page_name, properties)
+                    # Replace mode - drop existing properties, set only the new ones
+                    if self.db_mode:
+                        self._set_page_level_properties(page_name, properties)
+                    else:
+                        self._replace_page_properties(page_name, properties)
                     results.append(("properties", properties))
 
             return {"updates": results, "page": page_name}
@@ -666,12 +683,73 @@ class LogSeq:
             logger.warning(f"Could not get first block UUID for page '{page_name}'")
             return
 
-        # Set each property using upsertBlockProperty
+        # Set each property using upsertBlockProperty. Keys not listed here are
+        # left untouched, which gives append-mode its merge semantics natively.
         for key, value in properties.items():
             normalized_value = self._normalize_property_value(key, value)
             self._upsert_block_property(first_block_uuid, key, normalized_value)
 
         logger.info(f"Updated {len(properties)} properties on page '{page_name}'")
+
+    def _replace_page_properties(self, page_name: str, properties: dict) -> None:
+        """
+        Replace all page properties on the first block.
+
+        Unlike _update_page_properties (which only upserts the supplied keys),
+        this removes any existing first-block properties that are not in the new
+        set, then upserts the new ones. This preserves replace-mode semantics for
+        file graphs.
+        """
+        page_blocks = self.get_page_blocks(page_name)
+        if not page_blocks:
+            logger.warning(f"Page '{page_name}' has no blocks, cannot set properties")
+            return
+
+        first_block = page_blocks[0]
+        first_block_uuid = first_block.get("uuid")
+        if not first_block_uuid:
+            logger.warning(f"Could not get first block UUID for page '{page_name}'")
+            return
+
+        # Remove existing properties that are not part of the new set
+        existing_props = first_block.get("properties", {}) or {}
+        new_keys = set(properties.keys())
+        for key in existing_props:
+            if key not in new_keys:
+                self._remove_block_property(first_block_uuid, key)
+
+        # Upsert the new properties
+        for key, value in properties.items():
+            normalized_value = self._normalize_property_value(key, value)
+            self._upsert_block_property(first_block_uuid, key, normalized_value)
+
+        logger.info(f"Replaced properties on page '{page_name}' with {len(properties)} keys")
+
+    def _remove_block_property(self, block_uuid: str, key: str) -> None:
+        """
+        Remove a property from a block using Logseq's removeBlockProperty API.
+
+        Args:
+            block_uuid: UUID of the block to update
+            key: Property key to remove
+        """
+        url = self.get_base_url()
+
+        try:
+            response = requests.post(
+                url,
+                headers=self._get_headers(),
+                json={
+                    "method": "logseq.Editor.removeBlockProperty",
+                    "args": [block_uuid, key],
+                },
+                verify=self.verify_ssl,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+        except Exception as e:
+            logger.error(f"Failed to remove property '{key}' on block {block_uuid}: {e}")
+            raise
 
     def _upsert_block_property(self, block_uuid: str, key: str, value: Any) -> None:
         """

--- a/src/mcp_logseq/logseq.py
+++ b/src/mcp_logseq/logseq.py
@@ -664,6 +664,33 @@ class LogSeq:
             logger.error(f"Could not set page-level properties for '{page_name}': {e}")
             raise
 
+    def _resolve_first_block(self, page_name: str) -> dict:
+        """
+        Return the page's first block, creating an empty anchor block if none exists.
+
+        On file graphs, page properties live in the first block. A properties-only
+        update (no content) — especially in replace mode, which clears existing
+        blocks first — can leave the page with no block to write to. In that case
+        we create an empty anchor block, which is exactly how Logseq represents
+        page properties on a fresh page (the page-properties pre-block).
+
+        Raises:
+            RuntimeError: if no block exists and an anchor could not be created,
+                so the caller never reports a write that didn't happen.
+        """
+        page_blocks = self.get_page_blocks(page_name)
+        if page_blocks and page_blocks[0].get("uuid"):
+            return page_blocks[0]
+
+        anchor = self.append_block_in_page(page_name, "")
+        if anchor and anchor.get("uuid"):
+            return anchor
+
+        raise RuntimeError(
+            f"Could not resolve or create a first block on page '{page_name}' "
+            f"to store properties"
+        )
+
     def _update_page_properties(self, page_name: str, properties: dict) -> None:
         """
         Update page properties by setting them on the first block.
@@ -672,16 +699,7 @@ class LogSeq:
         using the `property:: value` syntax. This method updates properties
         by calling upsertBlockProperty on the first block.
         """
-        # Get first block of the page
-        page_blocks = self.get_page_blocks(page_name)
-        if not page_blocks:
-            logger.warning(f"Page '{page_name}' has no blocks, cannot set properties")
-            return
-
-        first_block_uuid = page_blocks[0].get("uuid")
-        if not first_block_uuid:
-            logger.warning(f"Could not get first block UUID for page '{page_name}'")
-            return
+        first_block_uuid = self._resolve_first_block(page_name)["uuid"]
 
         # Set each property using upsertBlockProperty. Keys not listed here are
         # left untouched, which gives append-mode its merge semantics natively.
@@ -700,16 +718,8 @@ class LogSeq:
         set, then upserts the new ones. This preserves replace-mode semantics for
         file graphs.
         """
-        page_blocks = self.get_page_blocks(page_name)
-        if not page_blocks:
-            logger.warning(f"Page '{page_name}' has no blocks, cannot set properties")
-            return
-
-        first_block = page_blocks[0]
-        first_block_uuid = first_block.get("uuid")
-        if not first_block_uuid:
-            logger.warning(f"Could not get first block UUID for page '{page_name}'")
-            return
+        first_block = self._resolve_first_block(page_name)
+        first_block_uuid = first_block["uuid"]
 
         # Remove existing properties that are not part of the new set
         existing_props = first_block.get("properties", {}) or {}

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -67,6 +67,7 @@ def _make_api() -> logseq.LogSeq:
         port=_api_port,
         verify_ssl=_api_verify_ssl,
         timeout=_api_timeout,
+        db_mode=_db_mode,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,14 @@ def mock_api_key():
 
 @pytest.fixture
 def logseq_client(mock_api_key):
-    """Create a LogSeq client instance for testing."""
+    """Create a LogSeq client instance for testing (file graph)."""
     return LogSeq(api_key=mock_api_key)
+
+
+@pytest.fixture
+def logseq_client_db(mock_api_key):
+    """Create a LogSeq client instance in DB-graph mode for testing."""
+    return LogSeq(api_key=mock_api_key, db_mode=True)
 
 
 @pytest.fixture

--- a/tests/unit/test_property_persistence.py
+++ b/tests/unit/test_property_persistence.py
@@ -83,166 +83,145 @@ class TestCreatePageProperties:
 
 
 class TestUpdatePageProperties:
-    """Test property persistence during page updates."""
+    """Test property persistence during page updates.
+
+    Property storage is graph-type dependent:
+      - DB graphs store page properties at the page entity level
+        (setPageProperties).
+      - File graphs store them as ``key:: value`` lines in the page's first
+        block (upsertBlockProperty / removeBlockProperty).
+    """
+
+    @staticmethod
+    def _calls_for(method):
+        return [c for c in responses.calls if method in str(c.request.body)]
+
+    # ------------------------------------------------------------------ #
+    # DB graph mode                                                      #
+    # ------------------------------------------------------------------ #
 
     @responses.activate
-    def test_update_page_append_mode_merges_properties(self, logseq_client):
-        """Test that append mode merges new properties with existing ones."""
-        # Mock list_pages for validation
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=[{"name": "Test Page", "originalName": "Test Page"}],
-            status=200,
+    def test_db_mode_append_merges_via_set_page_properties(self, logseq_client_db):
+        """DB graphs: append merges with existing page-level props via setPageProperties."""
+        url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, json=[{"name": "Test Page", "originalName": "Test Page"}], status=200)  # list_pages
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Existing"}], status=200)  # get last block
+        responses.add(responses.POST, url, json=[{"uuid": "block-2"}], status=200)  # insertBatchBlock
+        responses.add(responses.POST, url, json={"name": "Test Page", "properties": {"priority": "low", "status": "old"}}, status=200)  # getPage
+        responses.add(responses.POST, url, json=True, status=200)  # setPageProperties
+
+        result = logseq_client_db.update_page_with_blocks(
+            "Test Page", [{"content": "New content"}],
+            properties={"priority": "high", "tags": ["urgent"]}, mode="append",
         )
 
-        # Mock getPageBlocksTree for getting last block
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=[
-                {
-                    "uuid": "block-1",
-                    "content": "Existing",
-                    "properties": {"priority": "low"},
-                }
-            ],
-            status=200,
-        )
+        merged = dict(result["updates"])["properties"]
+        assert merged["priority"] == "high"   # overwritten
+        assert merged["status"] == "old"      # preserved from existing
+        assert merged["tags"] == ["urgent"]   # added
 
-        # Mock insertBatchBlock
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=[{"uuid": "block-2"}],
-            status=200,
-        )
-
-        # Mock getPage for _get_page_level_properties (returns existing page-level props)
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json={"name": "Test Page", "properties": {"priority": "low", "status": "old"}},
-            status=200,
-        )
-
-        # Mock setPageProperties for _set_page_level_properties
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=True,
-            status=200,
-        )
-
-        # Update with new properties in append mode
-        new_properties = {"priority": "high", "tags": ["urgent"]}
-        blocks = [{"content": "New content"}]
-        result = logseq_client.update_page_with_blocks(
-            "Test Page", blocks, properties=new_properties, mode="append"
-        )
-
-        # Verify properties were merged
-        updates = dict(result["updates"])
-        merged_props = updates["properties"]
-        assert merged_props["priority"] == "high"  # Overwritten
-        assert merged_props["status"] == "old"  # Preserved
-        assert merged_props["tags"] == ["urgent"]  # Added
-
-        # Verify setPageProperties was called (page-level, not block-level)
         import json
-        set_props_calls = [
-            call for call in responses.calls
-            if "setPageProperties" in str(call.request.body)
-        ]
-        assert len(set_props_calls) == 1
-        body = json.loads(set_props_calls[0].request.body)
-        assert body["method"] == "logseq.Editor.setPageProperties"
+        set_calls = self._calls_for("setPageProperties")
+        assert len(set_calls) == 1
+        body = json.loads(set_calls[0].request.body)
         assert body["args"][0] == "Test Page"
-
-        # Verify upsertBlockProperty was NOT called (would be block-level)
-        upsert_calls = [
-            call for call in responses.calls
-            if "upsertBlockProperty" in str(call.request.body)
-        ]
-        assert len(upsert_calls) == 0
+        # The full merged set is written page-level
+        assert body["args"][1]["status"] == "old"
+        assert self._calls_for("upsertBlockProperty") == []
 
     @responses.activate
-    def test_update_page_replace_mode_replaces_properties(self, logseq_client):
-        """Test that replace mode replaces all properties."""
-        # Mock list_pages for validation
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=[{"name": "Test Page", "originalName": "Test Page"}],
-            status=200,
+    def test_db_mode_replace_uses_set_page_properties(self, logseq_client_db):
+        """DB graphs: replace writes only the new props via setPageProperties."""
+        url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, json=[{"name": "Test Page", "originalName": "Test Page"}], status=200)  # list_pages
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Old", "properties": {"status": "old"}}], status=200)  # clear: get blocks
+        responses.add(responses.POST, url, json=True, status=200)  # removeBlock
+        responses.add(responses.POST, url, json={"uuid": "block-2", "content": "New"}, status=200)  # appendBlockInPage
+        responses.add(responses.POST, url, json=True, status=200)  # setPageProperties
+
+        result = logseq_client_db.update_page_with_blocks(
+            "Test Page", [{"content": "New content"}],
+            properties={"priority": "high"}, mode="replace",
         )
 
-        # Mock getPageBlocksTree for clearing
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=[
-                {
-                    "uuid": "block-1",
-                    "content": "Old",
-                    "properties": {"priority": "low", "status": "old"},
-                }
-            ],
-            status=200,
-        )
+        assert dict(result["updates"])["properties"] == {"priority": "high"}
+        assert len(self._calls_for("setPageProperties")) == 1
+        assert self._calls_for("upsertBlockProperty") == []
 
-        # Mock removeBlock
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=True,
-            status=200,
-        )
+    # ------------------------------------------------------------------ #
+    # File graph mode                                                    #
+    # ------------------------------------------------------------------ #
 
-        # Mock appendBlockInPage
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json={"uuid": "block-2", "content": "New"},
-            status=200,
-        )
+    @responses.activate
+    def test_file_mode_append_upserts_only_supplied_keys(self, logseq_client):
+        """File graphs: append upserts supplied keys in place on the first block.
 
-        # Mock setPageProperties for _set_page_level_properties
-        responses.add(
-            responses.POST,
-            "http://127.0.0.1:12315/api",
-            json=True,
-            status=200,
-        )
+        Untouched keys survive natively (no remove calls), which is what gives
+        append its merge semantics on file graphs.
+        """
+        url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, json=[{"name": "Test Page", "originalName": "Test Page"}], status=200)  # list_pages
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Existing", "properties": {"priority": "low", "status": "old"}}], status=200)  # get last block
+        responses.add(responses.POST, url, json=[{"uuid": "block-2"}], status=200)  # insertBatchBlock
+        responses.add(responses.POST, url, json={"name": "Test Page", "properties": {"priority": "low", "status": "old"}}, status=200)  # getPage (merge bookkeeping)
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Existing", "properties": {"priority": "low", "status": "old"}}], status=200)  # _update_page_properties: get first block
+        responses.add(responses.POST, url, json=True, status=200)  # upsertBlockProperty (repeats)
 
-        # Update with new properties in replace mode
-        new_properties = {"priority": "high"}
-        blocks = [{"content": "New content"}]
         result = logseq_client.update_page_with_blocks(
-            "Test Page", blocks, properties=new_properties, mode="replace"
+            "Test Page", [{"content": "New content"}],
+            properties={"priority": "high", "tags": ["urgent"]}, mode="append",
         )
 
-        # Verify only new properties are set (no merge)
-        updates = dict(result["updates"])
-        assert updates["properties"] == {"priority": "high"}
-        assert "status" not in updates["properties"]
+        # Result still reports the merged view for the caller
+        merged = dict(result["updates"])["properties"]
+        assert merged["priority"] == "high"
+        assert merged["status"] == "old"
+        assert merged["tags"] == ["urgent"]
 
-        # Verify setPageProperties was called (page-level, not block-level)
+        # Page properties go through the first block, NOT setPageProperties
+        assert self._calls_for("setPageProperties") == []
+
         import json
-        set_props_calls = [
-            call for call in responses.calls
-            if "setPageProperties" in str(call.request.body)
-        ]
-        assert len(set_props_calls) == 1
-        body = json.loads(set_props_calls[0].request.body)
-        assert body["method"] == "logseq.Editor.setPageProperties"
+        upsert_keys = {
+            json.loads(c.request.body)["args"][1] for c in self._calls_for("upsertBlockProperty")
+        }
+        assert upsert_keys == {"priority", "tags"}  # only supplied keys touched
+        # Untouched keys are never removed in append mode
+        assert self._calls_for("removeBlockProperty") == []
+        # All upserts target the first block
+        for c in self._calls_for("upsertBlockProperty"):
+            assert json.loads(c.request.body)["args"][0] == "block-1"
 
-        # Verify upsertBlockProperty was NOT called
-        upsert_calls = [
-            call for call in responses.calls
-            if "upsertBlockProperty" in str(call.request.body)
-        ]
-        assert len(upsert_calls) == 0
+    @responses.activate
+    def test_file_mode_replace_removes_stale_keys(self, logseq_client):
+        """File graphs: replace removes first-block props absent from the new set."""
+        url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, json=[{"name": "Test Page", "originalName": "Test Page"}], status=200)  # list_pages
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Old", "properties": {"priority": "low", "status": "old"}}], status=200)  # clear: get blocks
+        responses.add(responses.POST, url, json=True, status=200)  # removeBlock (clear content)
+        responses.add(responses.POST, url, json={"uuid": "block-2", "content": "New"}, status=200)  # appendBlockInPage anchor
+        responses.add(responses.POST, url, json=[{"uuid": "block-2", "content": "New", "properties": {"priority": "low", "status": "old"}}], status=200)  # _replace_page_properties: get first block
+        responses.add(responses.POST, url, json=True, status=200)  # removeBlockProperty / upsertBlockProperty (repeats)
+
+        result = logseq_client.update_page_with_blocks(
+            "Test Page", [{"content": "New content"}],
+            properties={"priority": "high"}, mode="replace",
+        )
+
+        assert dict(result["updates"])["properties"] == {"priority": "high"}
+        assert self._calls_for("setPageProperties") == []
+
+        import json
+        # "status" was present but not in the new set -> removed
+        removed_keys = {
+            json.loads(c.request.body)["args"][1] for c in self._calls_for("removeBlockProperty")
+        }
+        assert removed_keys == {"status"}
+        # "priority" upserted in place
+        upsert_keys = {
+            json.loads(c.request.body)["args"][1] for c in self._calls_for("upsertBlockProperty")
+        }
+        assert upsert_keys == {"priority"}
 
     @responses.activate
     def test_update_page_with_empty_properties_dict(self, logseq_client):

--- a/tests/unit/test_property_persistence.py
+++ b/tests/unit/test_property_persistence.py
@@ -224,6 +224,42 @@ class TestUpdatePageProperties:
         assert upsert_keys == {"priority"}
 
     @responses.activate
+    def test_file_mode_replace_properties_only_creates_anchor_block(self, logseq_client):
+        """File graphs: a properties-only replace must still persist the properties.
+
+        Regression: replace clears all blocks, leaving the page with no first
+        block. The property write previously logged a warning and returned while
+        the tool still reported success, wiping content and silently dropping the
+        properties. An empty anchor block must be created so the properties land.
+        """
+        url = "http://127.0.0.1:12315/api"
+        responses.add(responses.POST, url, json=[{"name": "Test Page", "originalName": "Test Page"}], status=200)  # list_pages
+        responses.add(responses.POST, url, json=[{"uuid": "block-1", "content": "Old", "properties": {"status": "old"}}], status=200)  # clear: get blocks
+        responses.add(responses.POST, url, json=True, status=200)  # removeBlock
+        responses.add(responses.POST, url, json=[], status=200)  # _resolve_first_block: page now empty
+        responses.add(responses.POST, url, json={"uuid": "anchor-1", "content": ""}, status=200)  # appendBlockInPage anchor
+        responses.add(responses.POST, url, json=True, status=200)  # upsertBlockProperty (repeats)
+
+        result = logseq_client.update_page_with_blocks(
+            "Test Page", [], properties={"priority": "high"}, mode="replace",
+        )
+
+        assert dict(result["updates"])["properties"] == {"priority": "high"}
+
+        import json
+        # An anchor block was created to hold the page properties
+        anchor_calls = self._calls_for("appendBlockInPage")
+        assert len(anchor_calls) == 1
+        assert json.loads(anchor_calls[0].request.body)["args"][0] == "Test Page"
+
+        # The properties were actually written to that anchor block
+        upserts = self._calls_for("upsertBlockProperty")
+        assert len(upserts) == 1
+        body = json.loads(upserts[0].request.body)
+        assert body["args"][0] == "anchor-1"
+        assert body["args"][1] == "priority"
+
+    @responses.activate
     def test_update_page_with_empty_properties_dict(self, logseq_client):
         """Test that empty properties dict doesn't cause errors."""
         # Mock list_pages for validation


### PR DESCRIPTION
Closes #48. Supersedes #49 (credited @nlsn as co-author for the repro and direction).

## Problem

`update_page` wrote page properties via `setPageProperties` for every graph type. On file graphs that appends a serialized property block to the page body instead of updating the `key:: value` lines in the first block, so the properties never register with Logseq's property system. The success message was misleading.

This is the same area @nlsn surfaced in #48 / #49. #49 fixed it by switching to `upsertBlockProperty` unconditionally, but that regresses DB graphs: block-level properties don't register as page-level there (invisible to `(page-property ...)` queries and the page info panel).

## Fix

Branch the property write path on graph type:

* DB graphs keep `setPageProperties` (page-entity level, the native representation that registers with `(page-property ...)`).
* File graphs use `upsertBlockProperty` on the first block, the native file-graph representation, updating values in place. This stays correct even after the upstream `setPageProperties` behavior in #51 is addressed.

Append and replace semantics are preserved in both modes:

* append upserts only the supplied keys, so untouched keys survive (merge semantics),
* replace removes first-block keys absent from the new set before upserting, via new `_replace_page_properties` / `_remove_block_property`.

The `db_mode` flag is plumbed from `tools.py` into the `LogSeq` client.

## Tests

Rewrote the two property-update tests into four covering append and replace across both graph types, asserting the actual API call sequence (which method is called, on which block, with which keys) rather than only the returned dict. Full suite: 417 passing.
