### PR TITLE
minor documentation update to indicate that vector extras are required for tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,8 +21,8 @@ cd mcp-logseq
 # Install dependencies
 uv sync
 
-# Install development dependencies
-uv sync --dev
+# Install development dependencies (including vector extras required for tests)
+uv sync --dev --extra vector
 ```
 
 ### 2. Environment Configuration


### PR DESCRIPTION
Alternatively, we can update the pyproject.toml to include vector group in the dev.  Happy to submit a new PR if that is preferred.

This can avoid surprises while #66 is sorted out.