### PR TITLE
feat: HTTP/SSE transport with secure multi-profile serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ If you hit the "already exists" error mid-ingest, use `get_page_content` to see 
 - **`LOGSEQ_EXCLUDE_TAGS`** (optional): Comma-separated tags — pages with these tags are hidden from all tools. See [Privacy & Access Control](#-privacy--access-control) below.
 - **`LOGSEQ_INCLUDE_NAMESPACES`** (optional): Comma-separated namespace allow-list (e.g. `work,projects`). When set, **only** pages in these namespaces and their sub-pages are accessible — everything else, including top-level pages without a namespace, is hidden from listings/search and denied on direct access. See [Privacy & Access Control](#-privacy--access-control) below.
 - **`LOGSEQ_EXCLUDE_NAMESPACES`** (optional): Comma-separated namespace deny-list (e.g. `finance,work/secret`). These namespaces are always blocked, taking priority over the include list. See [Privacy & Access Control](#-privacy--access-control) below.
+- **`LOGSEQ_CONFIG_FILE`** (optional): Path to a shared JSON config file holding the graph path, ACL defaults, and the `vector` block. Env vars (`LOGSEQ_EXCLUDE_TAGS`, `LOGSEQ_INCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_NAMESPACES`) override the matching keys in this file.
+- **`MCP_HTTP_AUTH_TOKEN`** (required for `--transport http`): Bearer token clients must send as `Authorization: Bearer <token>`. The server refuses to start in HTTP mode without it. See [Serving over HTTP](#-serving-over-http-multi-profile) below.
 
 ### Privacy & Access Control
 
@@ -262,6 +264,74 @@ LOGSEQ_EXCLUDE_NAMESPACES=work/secret,finance
 Matching is segment-based and case-insensitive: `work` matches `work` and `work/projects` but not `workshop`. The behavior mirrors `LOGSEQ_EXCLUDE_TAGS`: list/search results silently omit blocked pages; direct read, write, delete, and block operations return an access-denied error.
 
 **Known limitation:** access control is enforced at the **page** level. `search` and `query` filter out whole pages that are blocked, but individual blocks returned by a `query` DSL or by full-text `search` are not resolved back to their owning page, so a block belonging to a restricted page can still surface in those block-level results. Page listings, direct page/block access, backlinks, and vector search are all filtered; tighten DSL queries accordingly if this matters for your setup.
+
+### 🔒 Security model
+
+When serving multiple clients over HTTP, isolation rests on a few guarantees:
+
+- **ACL is enforced server-side, before any bytes leave the process.** Blocked pages are filtered out of listings/search and denied on direct read/write — a client never receives content it isn't scoped to.
+- **Bearer auth.** Every HTTP request must carry `Authorization: Bearer <MCP_HTTP_AUTH_TOKEN>`; unauthenticated requests are rejected.
+- **Loopback binding.** Default `--host 127.0.0.1`; never `0.0.0.0`.
+- **Process-boundary isolation.** Multi-instance means one profile's config (token, namespace scope, excluded tags) is never loaded by another process.
+- **Read tools** enforce namespace allow/deny *or* tag exclusion. **Write tools** enforce namespace gating plus tag-on-write checks against the existing page, so a write can't slip into a blocked namespace or onto an excluded page.
+- **Tag matching is case-SENSITIVE; namespace matching is case-INSENSITIVE.** Namespaces match regardless of case (`work` matches `Work/Projects`), but `LOGSEQ_EXCLUDE_TAGS` / `vector.exclude_tags` must match the **stored** tag casing exactly. Logseq typically stores tags lowercased, so `LOGSEQ_EXCLUDE_TAGS=Secret` will **not** exclude a page tagged `secret`. Match the casing as stored, or a page you meant to hide stays visible.
+
+### 🌐 Serving over HTTP (multi-profile)
+
+By default the server speaks **stdio** — the local client spawns it as a subprocess. For serving sandboxed or remote clients (each one only allowed to see a slice of your graph), the server can also run as a long-lived **HTTP** process:
+
+```bash
+mcp-logseq --transport http --host 127.0.0.1 --port 12320
+```
+
+- `--transport {stdio,http}` — default `stdio`.
+- `--host` — default `127.0.0.1` (loopback). **Never bind to `0.0.0.0`.** ACL is enforced server-side, but binding to a public interface would still expose the auth-token surface to the network; keep it on loopback or a host-internal interface.
+- `--port` — default `12320`.
+- `--read-only` — unregisters the 8 write tools (see [Security model](#-security-model)); read tools and the vector tools remain.
+
+HTTP mode **requires** `MCP_HTTP_AUTH_TOKEN`; the server exits if it is missing. Clients authenticate with `Authorization: Bearer <token>` and target the MCP endpoint at **`/mcp`**. (A bare POST to `/mcp` issues a `307` redirect to `/mcp/`; point clients at `/mcp` and follow redirects, or use `/mcp/` directly.)
+
+#### Step 1 — one instance per profile
+
+A **profile** is one shared data config file + a per-process env block (namespace/tags/token) + its own port. Run **one instance per profile**. Every instance loads the *same* data config file (graph path, vector `db_path`, embedder); what differs is the per-process env block — and that env block **is** the profile.
+
+```bash
+# "journal-assistant" — reads your diary and reflects back, but can never edit it.
+# Whole-instance read-only: no write tools at all.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Journal \
+MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
+mcp-logseq --transport http --port 12320 --read-only
+
+# "work" — full read/write within Work/, and explicitly no diary access.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Work \
+LOGSEQ_EXCLUDE_NAMESPACES=Journal \
+MCP_HTTP_AUTH_TOKEN=$WORK_TOKEN \
+mcp-logseq --transport http --port 12321
+
+# "personal" — broad read/write, but credentials stay invisible.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_EXCLUDE_TAGS=keys,secret \
+MCP_HTTP_AUTH_TOKEN=$PERSONAL_TOKEN \
+mcp-logseq --transport http --port 12322
+```
+
+The `LOGSEQ_CONFIG_FILE` is identical across all three instances; the per-process env block is what makes each one a distinct profile. Because each instance is its own process, one profile's env (token, namespace scope, excluded tags) is never loaded by another — isolation is the process boundary.
+
+#### Step 2 — the separate sync writer
+
+The vector DB has exactly **one** writer: a dedicated `logseq-sync` process deployed **outside** every MCP instance. It indexes the whole graph under a single global policy — `vector.exclude_tags` should hold only the secrets/never-store tags. Per-profile differentiation is purely *query-time* on the reader instances above; the index itself is shared.
+
+```bash
+# Continuous writer (launchd / systemd unit), owns the DB — same shared data file:
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --watch
+
+# Or scheduled one-shot (cron / launchd StartInterval):
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --once
+```
+
+`logseq-sync` reads **no ACL env** — only the `vector` block and graph path from the data file. (`--rebuild` drops and re-indexes from scratch; `--status` prints a staleness report.) The reader profiles open the same `db_path` read-only and never run sync: the MCP `sync_vector_db` tool is inert and simply points operators at this external writer.
 
 ### Alternative Setup Methods
 

--- a/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
+++ b/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
@@ -35,7 +35,7 @@ Because the ACL globals are loaded at import time and live per-process, **runnin
 
 The vector DB is a single on-disk store shared by all reader instances. ACL controls operate on **two axes** — index-time (global, what the DB contains) vs query-time (per-instance, what a profile sees). **Do not conflate them:**
 
-- **Index-time — `vector` block, the writer's single global policy.** `vector.exclude_tags`, plus (new, Task 7) `vector.include_namespaces` / `vector.exclude_namespaces`. Decides what is ever embedded/stored. Use it for (a) content no tier may ever vector-search (e.g. `#secret` raw credentials → `exclude_tags`) and (b) namespaces irrelevant or off-limits to *everyone* (`exclude_namespaces`), or to scope the whole DB to a subset (`include_namespaces`). Anything excluded here is gone for **every** profile — and never embedded, so it also shrinks the DB (less disk, less sync compute, faster search as the vault grows).
+- **Index-time — `vector` block, the writer's single global policy.** `vector.exclude_tags` (exists) decides what is ever embedded/stored — use it for content no tier may ever vector-search (e.g. `#secret` raw credentials). Anything excluded here is gone for **every** profile and never embedded. *(An index-time **namespace** equivalent — `vector.include_namespaces` / `vector.exclude_namespaces` — is a separate, transport-independent feature tracked in [index-time namespace scoping](2026-06-15-index-time-namespace-scoping.md); it composes with this model but is out of scope for this plan.)*
 - **Query-time — env per instance → `_exclude_tags` / `_include_namespaces` / `_exclude_namespaces`.** Decides which profile sees which already-stored content. This is the per-tier wall.
 
 **Single writer, separated from readers (decided).** Exactly one dedicated process owns the DB — `logseq-sync --watch` (or `--once` under launchd/systemd/cron), guarded by the existing `sync.lock` ([bin/logseq_sync.py:45-60](../../../src/mcp_logseq/bin/logseq_sync.py#L45-L60)). It indexes with the **single fixed index policy** above. **No MCP instance triggers sync at all:** `sync_vector_db`'s handler no longer spawns a subprocess — it returns instructions to run `logseq-sync` externally (Task 5b). Since it is then inert (returns text, mutates nothing), `--read-only` does not special-case it. This makes "whose index policy wins" impossible: there is one writer with one policy, and all per-tier differentiation is query-time.
@@ -91,13 +91,11 @@ A profile is therefore "the shared data file + a unit file's env block." Adding 
 - Modify: `src/mcp_logseq/server.py` — factor tool registration into an importable `build_app()` so both stdio and HTTP reuse it; add transport dispatch.
 - Modify: `src/mcp_logseq/__init__.py` — `main()` parses `--transport {stdio,http}`, `--host`, `--port`, `--read-only`.
 - Modify: `src/mcp_logseq/vector/index.py` — `vector_search` query-time tag filter (Task 4); `sync_vector_db` external-pointer stub (Task 5b).
-- Modify: `src/mcp_logseq/config.py` — `VectorConfig` + `load_vector_config` gain `include_namespaces`/`exclude_namespaces` (Task 7).
-- Modify: `src/mcp_logseq/vector/chunker.py` — index-time namespace filter in `chunk_file` (Task 7).
 - Modify: `pyproject.toml` — bump `mcp` to a version with Streamable HTTP; add `starlette`, `uvicorn`; (optional) `serve` console alias.
 - Create: `tests/unit/test_http_transport.py`
 - Create: `tests/integration/test_http_serving.py`
 - Modify: `tests/unit/test_namespace_access.py` — extend to assert the guard holds on every content-returning tool, incl. the `vector_search` tag gap (Task 4) and `--read-only` (Task 5).
-- Modify: `tests/unit/test_chunker.py` — index-time namespace scoping (Task 7); `tests/unit/test_vector_tools.py` — `sync_vector_db` stub (Task 5b).
+- Modify: `tests/unit/test_vector_tools.py` — `sync_vector_db` stub (Task 5b).
 - Modify: `README.md` — document host-serving, the per-profile multi-instance pattern, the separate sync writer, and the security model.
 
 ---
@@ -415,7 +413,7 @@ mcp-logseq --transport http --port 12322
 
 The data file is identical across all three; the per-process env block *is* the profile. The diary use case maps cleanly to whole-instance `--read-only`: `journal-assistant` reads `Journal/` and answers but holds zero write tools, while `work` excludes `Journal/` entirely. Bind to loopback (or a host-internal interface), never `0.0.0.0`.
 
-- [ ] **Step 2: Document the separate sync writer.** The vector DB is owned by **one** dedicated `logseq-sync` process, deployed outside every MCP instance. It indexes with the single global index policy (`vector.exclude_tags` = secrets only, plus optional `vector.include_namespaces`/`vector.exclude_namespaces` to scope the whole DB — Task 7); per-tier differentiation is purely query-time on the reader instances. Show both deployment shapes:
+- [ ] **Step 2: Document the separate sync writer.** The vector DB is owned by **one** dedicated `logseq-sync` process, deployed outside every MCP instance. It indexes with the single global index policy (`vector.exclude_tags` = secrets only; optional index-time namespace scoping is a separate feature — see [its plan](2026-06-15-index-time-namespace-scoping.md)); per-tier differentiation is purely query-time on the reader instances. Show both deployment shapes:
 
 ````markdown
 # Continuous writer (launchd / systemd unit), owns the DB — same shared data file:
@@ -429,30 +427,9 @@ The writer reads no ACL env — only the `vector` block and `graph_path` from `d
 
 - [ ] **Step 3: Commit** — `git commit -m "docs: per-profile HTTP serving, separate sync writer, security model"`
 
-### Task 7: Index-time namespace scoping (writer global policy)
-
-Symmetric with the existing index-time `vector.exclude_tags`: let the writer scope what the shared DB contains by namespace, so content irrelevant or off-limits to *every* profile is never embedded (smaller DB, less sync compute, faster search). This is **global** index policy — distinct from the per-instance query-time namespace ACL.
-
-**Files:**
-- Modify: `src/mcp_logseq/config.py` (`VectorConfig` + `load_vector_config`)
-- Modify: `src/mcp_logseq/vector/chunker.py` (`chunk_file`)
-- Test: `tests/unit/test_chunker.py`
-
-- [ ] **Step 1: Write failing tests** — a `VectorConfig` with `exclude_namespaces=["Journal"]` makes `chunk_file` return `[]` for a `Journal/*` page; with `include_namespaces=["Work"]`, only `Work/*` pages produce chunks. Pages outside the scope yield no chunks.
-
-- [ ] **Step 2: Run to verify fail** — Expected: FAIL (fields/filter absent).
-
-- [ ] **Step 3: Implement** — add `include_namespaces: list[str]` / `exclude_namespaces: list[str]` to `VectorConfig` (default `[]`), parse them from the `vector` block in `load_vector_config`. In `chunk_file`, after `page_title` is derived, reuse the same allow/deny semantics as `tools._is_namespace_blocked` (exclude wins; include is a strict allow-list) and `return []` when the page's namespace is blocked — mirror the existing `exclude_tags` early-return just above it.
-
-- [ ] **Step 4: Run to verify pass.** A changed index policy requires `logseq-sync --rebuild` to take effect (note this in the README sync section); incremental sync skips unchanged files by content hash.
-
-- [ ] **Step 5: Commit** — `git commit -m "feat(vector): index-time include/exclude namespace scoping"`
-
----
-
 ## Phase 3 — Acceptance
 
-### Task 8: End-to-end serving + isolation
+### Task 7: End-to-end serving + isolation
 
 **Files:**
 - Create: `tests/integration/test_http_serving.py`
@@ -461,9 +438,8 @@ Symmetric with the existing index-time `vector.exclude_tags`: let the writer sco
 - [ ] **Step 2 (auth):** request with no/wrong token → 401; with the right token → MCP handshake succeeds.
 - [ ] **Step 3 (isolation):** via the authenticated client, exercise search, vector search, and a direct get/query for a `Work/*` page → none surface `Work/*`; a `Journal/*` query returns results.
 - [ ] **Step 4 (writes):** if not `--read-only`, a write to `Work/*` → `AccessDenied`; with `--read-only`, no write tool is listed (but `sync_vector_db` stub and read tools remain).
-- [ ] **Step 5 (index scope):** with the writer configured `vector.exclude_namespaces=["Secret"]`, a `Secret/*` page is absent from `vector_search` for **all** profiles (not merely filtered).
-- [ ] **Step 6:** Run: `uv run pytest tests/integration/test_http_serving.py -v` — Expected: PASS. Record outcomes; only then mark serving complete.
-- [ ] **Step 7: Commit** — `git commit -m "test(integration): end-to-end HTTP serving + profile isolation"`
+- [ ] **Step 5:** Run: `uv run pytest tests/integration/test_http_serving.py -v` — Expected: PASS. Record outcomes; only then mark serving complete.
+- [ ] **Step 6: Commit** — `git commit -m "test(integration): end-to-end HTTP serving + profile isolation"`
 
 ---
 
@@ -477,7 +453,7 @@ Symmetric with the existing index-time `vector.exclude_tags`: let the writer sco
 
 ## Self-Review Notes
 
-- **Spec coverage:** transport (Task 1), auth (Task 2), CLI/bind (Task 3), full-surface ACL audit incl. `vector_search` tag gap (Task 4), `--read-only` + tag-on-write (Task 5), `sync_vector_db` external-pointer stub (Task 5b), per-profile + separate-writer docs (Task 6), index-time namespace scoping (Task 7), acceptance incl. index-scope check (Task 8). Covered.
+- **Spec coverage:** transport (Task 1), auth (Task 2), CLI/bind (Task 3), full-surface ACL audit incl. `vector_search` tag gap (Task 4), `--read-only` + tag-on-write (Task 5), `sync_vector_db` external-pointer stub (Task 5b), per-profile + separate-writer docs (Task 6), acceptance (Task 7). Covered. Index-time namespace scoping is split into its own plan (transport-independent).
 - **Reuse over rebuild:** ACL and per-profile config already exist; Tasks 4–5 *audit and extend* the existing guard rather than introduce a new one. **Namespace gating on writes is already complete** (PR #65, incl. `rename_page` dual-endpoint) — Task 5 adds only `--read-only` and the recommended tag-on-write check, not namespace gating.
 - **Config model:** one shared data/vector config file (writer-owned) + per-reader policy via env (namespace/tags/token) — leverages existing env-over-file precedence, no merge code, no `db_path`/`embedder` drift.
 - **Isolation:** multi-instance (process boundary), not multi-tenant (runtime lookup) — decided in What ALREADY Exists / Isolation model.

--- a/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
+++ b/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
@@ -1,0 +1,351 @@
+# HTTP/SSE Transport + Secure Multi-Profile Serving Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `mcp-logseq` run as a networked HTTP/SSE service on the host so a sandboxed client (e.g. an agent running inside a container) can reach it without any filesystem mount or direct Logseq-API access — making the existing namespace/tag access control a real security boundary.
+
+**Architecture:** The server currently runs stdio-only and is therefore co-located with its client. Its access-control layer (include/exclude namespaces, exclude tags, per-config-file "profiles") already exists and is fail-closed. The missing piece is a network transport: add an HTTP/SSE (Streamable HTTP) entry mode with bearer-token auth, bound to a configurable interface, so the server can sit on the host owning the raw data (vector DB + Logseq HTTP API on loopback) while the client gets only filtered tool results over HTTP. Multiple single-profile instances (one config file + one port each) provide per-profile isolation with zero new multi-tenant code.
+
+**Tech Stack:** Python, MCP Python SDK (`mcp` — Streamable HTTP server transport), Starlette + uvicorn (ASGI host), existing `mcp.server.Server` app, existing `config.py` ACL loaders.
+
+---
+
+## Consumer Model (context, not in scope)
+
+The client is a **sandboxed agent** — assume it runs in a container or other locked-down environment and must never touch raw data. In the target deployment the agent has **no** bind mounts of the vault or vector DB and **no** network route to the Logseq HTTP API; its only Logseq channel is this server's HTTP endpoint. All access control therefore has to be enforced **server-side, before any bytes leave the process**. Wiring the client/container/network is a separate concern in the consuming application and is **out of scope for this plan** — this plan only makes the server securely servable over the network.
+
+---
+
+## What ALREADY Exists (do NOT rebuild)
+
+Confirmed in the current tree — the developer should reuse, not reimplement:
+
+- **Per-profile config** via `LOGSEQ_CONFIG_FILE` → `src/mcp_logseq/config.py`: `load_include_namespaces()`, `load_exclude_namespaces()`, `load_exclude_tags()`, plus the `vector` block. A "profile" is one config file. Each process loads exactly one.
+- **ACL enforcement, fail-closed**, in `src/mcp_logseq/tools.py`: module-level `_include_namespaces` / `_exclude_namespaces` / `_exclude_tags` (lines 59-61), `_is_namespace_blocked`, `_is_page_blocked`, `_enforce_namespace_access` (raises `AccessDenied`), `_enforce_block_namespace_access` (fail-closed when a block's page can't be resolved). Search/query result filtering at `tools.py:1241, 1382, 1508`.
+- **Vector-search filtering** in `src/mcp_logseq/vector/index.py:230` using the same namespace globals.
+- **stdio transport** in `src/mcp_logseq/server.py:83-89` (`stdio_server()`), entry `mcp-logseq = "mcp_logseq:main"` → `server.main()`.
+
+Because the ACL globals are loaded at import time and live per-process, **running N instances with N config files needs no refactor of the ACL layer.** The work is transport + auth + a completeness audit of the network surface.
+
+---
+
+## Scope (in / out)
+
+**In scope (vector + normal search era):**
+- HTTP/SSE transport with bearer auth and configurable bind address, selectable without breaking stdio.
+- A documented "one instance per profile" run pattern.
+- A security audit ensuring **every content-returning tool** enforces the ACL over the new HTTP surface, and a policy for write tools.
+
+**Out of scope (now):**
+- Vault/raw-file browsing for the client (the user will use the Logseq web app for read-only browsing).
+- Single-page "fetch + KB formatting" as a distinct product feature (formatting lives in the consumer).
+- Any consumer/container/network wiring.
+
+---
+
+## Open Decisions (resolve before the dependent task)
+
+- **[DECIDE-A] Transport flavor.** Streamable HTTP (current MCP recommendation) vs legacy SSE. Default to **Streamable HTTP**; only fall back to SSE if the pinned `mcp` version lacks it. *Dependent: Task 1.*
+- **[DECIDE-B] Auth token source.** Read the endpoint bearer token from an env var (`MCP_HTTP_AUTH_TOKEN`) and/or a config-file key. Default: env var, required when `--transport http`. *Dependent: Task 2.*
+- **[DECIDE-C] Write tools over HTTP.** Either (a) keep write tools exposed but ensure each is gated by `_enforce_namespace_access` before mutating, or (b) add a per-instance `--read-only` flag that unregisters write tools entirely. Recommended: implement **both** — (a) is the correctness floor, (b) is the simplest hard guarantee per profile. *Dependent: Task 5.*
+
+---
+
+## File Structure
+
+- Create: `src/mcp_logseq/transport/__init__.py`
+- Create: `src/mcp_logseq/transport/http.py` — ASGI app wrapping the existing `Server`, bearer-auth middleware, uvicorn runner.
+- Modify: `src/mcp_logseq/server.py` — factor tool registration into an importable `build_app()` so both stdio and HTTP reuse it; add transport dispatch.
+- Modify: `src/mcp_logseq/__init__.py` — `main()` parses `--transport {stdio,http}`, `--host`, `--port`.
+- Modify: `pyproject.toml` — bump `mcp` to a version with Streamable HTTP; add `starlette`, `uvicorn`; (optional) `serve` console alias.
+- Create: `tests/unit/test_http_transport.py`
+- Create: `tests/integration/test_http_serving.py`
+- Modify: `tests/unit/test_namespace_access.py` — extend to assert the guard holds on every content-returning tool (Task 4).
+- Modify: `README.md` — document host-serving, the per-profile multi-instance pattern, and the security model.
+
+---
+
+## Phase 1 — HTTP transport
+
+### Task 1: Factor `build_app()` and add the HTTP ASGI module
+
+**Files:**
+- Modify: `src/mcp_logseq/server.py`
+- Create: `src/mcp_logseq/transport/__init__.py` (empty)
+- Create: `src/mcp_logseq/transport/http.py`
+- Modify: `pyproject.toml`
+- Test: `tests/unit/test_http_transport.py`
+
+- [ ] **Step 1: Resolve [DECIDE-A].** Confirm the pinned `mcp` version exposes Streamable HTTP (`from mcp.server.streamable_http_manager import StreamableHTTPSessionManager` or equivalent). Record the exact import path here. If absent, bump `mcp` in `pyproject.toml` and re-sync (`uv sync`).
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/unit/test_http_transport.py
+import pytest
+from starlette.testclient import TestClient
+from mcp_logseq.transport.http import create_asgi_app
+
+def test_asgi_app_mounts_mcp_endpoint(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    monkeypatch.setenv("MCP_HTTP_AUTH_TOKEN", "secret")
+    app = create_asgi_app(auth_token="secret")
+    client = TestClient(app)
+    # No/!bad bearer → 401 (auth covered in Task 2; here assert the route exists)
+    resp = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert resp.status_code in (401, 400)  # route exists, not 404
+```
+
+- [ ] **Step 3: Run to verify fail** — Run: `uv run pytest tests/unit/test_http_transport.py -v` — Expected: FAIL (module `transport.http` missing).
+
+- [ ] **Step 4: Refactor `server.py`** so tool registration is reusable:
+
+```python
+# server.py — extract everything that registers tool handlers into:
+def build_app() -> Server:
+    app = Server("mcp-logseq")
+    _register_all_tool_handlers(app)   # the existing add_tool_handler(...) calls
+    return app
+```
+
+Keep `main()`'s stdio path calling `build_app()` so behavior is unchanged.
+
+- [ ] **Step 5: Implement `transport/http.py`**
+
+```python
+# src/mcp_logseq/transport/http.py
+import contextlib
+from collections.abc import AsyncIterator
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager  # confirm in Step 1
+from ..server import build_app
+
+def create_asgi_app(auth_token: str) -> Starlette:
+    app = build_app()
+    manager = StreamableHTTPSessionManager(app=app)
+
+    async def handle(scope, receive, send):
+        await manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_: Starlette) -> AsyncIterator[None]:
+        async with manager.run():
+            yield
+
+    asgi = Starlette(routes=[Mount("/mcp", app=handle)], lifespan=lifespan)
+    from .auth import BearerAuthMiddleware     # added in Task 2
+    asgi.add_middleware(BearerAuthMiddleware, token=auth_token)
+    return asgi
+
+def run_http(host: str, port: int, auth_token: str) -> None:
+    import uvicorn
+    uvicorn.run(create_asgi_app(auth_token), host=host, port=port)
+```
+
+- [ ] **Step 6: Add deps** to `pyproject.toml` (`starlette`, `uvicorn`, bumped `mcp`); `uv sync`.
+
+- [ ] **Step 7: Run to verify pass** — Run: `uv run pytest tests/unit/test_http_transport.py -v` — Expected: PASS.
+
+- [ ] **Step 8: Commit** — `git commit -m "feat(transport): HTTP/SSE ASGI app wrapping the MCP server"`
+
+### Task 2: Bearer-token auth middleware
+
+**Files:**
+- Create: `src/mcp_logseq/transport/auth.py`
+- Test: `tests/unit/test_http_transport.py` (extend)
+
+- [ ] **Step 1: Resolve [DECIDE-B].** Confirm token source = `MCP_HTTP_AUTH_TOKEN` (required in http mode). Record here.
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+def test_missing_token_is_401(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    client = TestClient(create_asgi_app(auth_token="secret"))
+    r = client.post("/mcp", json={"jsonrpc":"2.0","id":1,"method":"ping"})
+    assert r.status_code == 401
+
+def test_wrong_token_is_401(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    client = TestClient(create_asgi_app(auth_token="secret"))
+    r = client.post("/mcp", headers={"Authorization": "Bearer nope"},
+                    json={"jsonrpc":"2.0","id":1,"method":"ping"})
+    assert r.status_code == 401
+```
+
+- [ ] **Step 3: Run to verify fail** — Expected: FAIL (no auth module / 404).
+
+- [ ] **Step 4: Implement `auth.py`**
+
+```python
+# src/mcp_logseq/transport/auth.py
+import hmac
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+class BearerAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, token: str):
+        super().__init__(app)
+        self._token = token
+
+    async def dispatch(self, request, call_next):
+        auth = request.headers.get("Authorization", "")
+        prefix = "Bearer "
+        presented = auth[len(prefix):] if auth.startswith(prefix) else ""
+        if not presented or not hmac.compare_digest(presented, self._token):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+        return await call_next(request)
+```
+
+- [ ] **Step 5: Run to verify pass** — Expected: PASS (both 401 tests).
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(transport): bearer-token auth middleware for HTTP endpoint"`
+
+### Task 3: `--transport` CLI dispatch + bind address
+
+**Files:**
+- Modify: `src/mcp_logseq/__init__.py`
+- Modify: `pyproject.toml` (optional `serve` alias)
+- Test: `tests/unit/test_cli.py` (create)
+
+- [ ] **Step 1: Write the failing test** — `parse_args(["--transport","http","--host","127.0.0.1","--port","12320"])` returns a namespace with those values; default (no args) → `transport="stdio"`.
+
+- [ ] **Step 2: Run to verify fail** — Expected: FAIL.
+
+- [ ] **Step 3: Implement** an `argparse` layer in `__init__.py`:
+
+```python
+def main():
+    import argparse, asyncio
+    p = argparse.ArgumentParser(prog="mcp-logseq")
+    p.add_argument("--transport", choices=["stdio", "http"], default="stdio")
+    p.add_argument("--host", default="127.0.0.1")   # loopback default; never 0.0.0.0
+    p.add_argument("--port", type=int, default=12320)
+    args = p.parse_args()
+    if args.transport == "stdio":
+        from . import server
+        asyncio.run(server.main())
+    else:
+        import os
+        token = os.environ.get("MCP_HTTP_AUTH_TOKEN")
+        if not token:
+            raise SystemExit("MCP_HTTP_AUTH_TOKEN is required for --transport http")
+        from .transport.http import run_http
+        run_http(args.host, args.port, token)
+```
+
+- [ ] **Step 4: Run to verify pass** — Expected: PASS. Also smoke-test stdio is unchanged: `echo '' | uv run mcp-logseq` still starts the stdio server.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(cli): --transport http|stdio with loopback-default bind"`
+
+---
+
+## Phase 2 — Per-profile multi-instance
+
+### Task 4 (audit): every content-returning tool enforces the ACL
+
+This is the real security work: the HTTP surface exposes the **full tool set**, so any tool that can return page/block content — not just search — must enforce the namespace/tag guard. A client could otherwise name a denied page directly or run a DSL `query` that returns blocks from a denied namespace.
+
+**Files:**
+- Modify: `tests/unit/test_namespace_access.py`
+- Modify: any tool handler in `src/mcp_logseq/tools.py` found to bypass the guard.
+
+- [ ] **Step 1: Enumerate** every registered tool that returns block/page content (search, vector search, direct get-page/get-block, DSL `query`, backlinks, list-pages, namespace listings). Write the list into the test file as a checklist comment.
+
+- [ ] **Step 2: Write failing tests** — with a profile that denies `Private/*`, assert each enumerated tool, when asked for or able to surface a `Private/*` page, returns nothing for it or raises `AccessDenied`. Example:
+
+```python
+def test_dsl_query_cannot_return_denied_namespace(denied_private_profile, api_stub):
+    # api returns a Private/* block; tool must filter/deny it
+    out = run_tool("query", {"query": "(page-tags)"})
+    assert "Private/" not in serialize(out)
+
+def test_direct_get_page_denied(denied_private_profile):
+    with pytest.raises(AccessDenied):
+        run_tool("get_page", {"name": "Private/Health"})
+```
+
+- [ ] **Step 3: Run to verify fail** — Expected: FAIL for any tool currently missing the guard.
+
+- [ ] **Step 4: Add `_enforce_namespace_access` / `_is_page_blocked` filtering** to each bypassing tool (mirror the existing pattern at `tools.py:1241/1382/1508`). For DSL `query`, filter the returned block list by each block's owning page.
+
+- [ ] **Step 5: Run to verify pass** — Expected: PASS for all enumerated tools.
+
+- [ ] **Step 6: Commit** — `git commit -m "fix(acl): enforce namespace/tag guard on all content-returning tools"`
+
+### Task 5: Write-tool policy (gated + optional read-only)
+
+**Files:**
+- Modify: `src/mcp_logseq/tools.py` (write handlers) and `src/mcp_logseq/__init__.py` / `server.py` (`--read-only`)
+- Test: `tests/unit/test_namespace_access.py`
+
+- [ ] **Step 1: Resolve [DECIDE-C].** Confirm both (a) gate writes and (b) `--read-only`.
+
+- [ ] **Step 2: Write failing tests** — (a) `create_page`/`update_block`/`set_block_properties`/`insert_nested_block`/`delete_block` targeting `Private/*` raise `AccessDenied`; (b) with `--read-only`, write tools are absent from `list_tools()`.
+
+- [ ] **Step 3: Run to verify fail** — Expected: FAIL.
+
+- [ ] **Step 4: Implement** — call `_enforce_namespace_access(target_page)` (and `_enforce_block_namespace_access` for block-targeted writes) at the top of each write handler; add a `--read-only` flag threaded into `build_app()` that skips registering write handlers.
+
+- [ ] **Step 5: Run to verify pass** — Expected: PASS.
+
+- [ ] **Step 6: Commit** — `git commit -m "feat(acl): gate writes by namespace + per-instance --read-only"`
+
+### Task 6: Document the per-profile run pattern
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1:** Document that a "profile" = one config file, and you run one instance per profile on its own port, each with its own `MCP_HTTP_AUTH_TOKEN`:
+
+````markdown
+# Journal-only profile
+LOGSEQ_CONFIG_FILE=~/.logseq/profiles/journal.json \
+MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
+mcp-logseq --transport http --port 12320
+
+# Work-only profile (separate process, separate port, separate token)
+LOGSEQ_CONFIG_FILE=~/.logseq/profiles/work.json \
+MCP_HTTP_AUTH_TOKEN=$WORK_TOKEN \
+mcp-logseq --transport http --port 12321
+````
+
+Note: each instance loads exactly one config, so namespace scoping is per-process. Bind to loopback (or a host-internal interface), never `0.0.0.0`.
+
+- [ ] **Step 2: Commit** — `git commit -m "docs: per-profile HTTP serving and security model"`
+
+---
+
+## Phase 3 — Acceptance
+
+### Task 7: End-to-end serving + isolation
+
+**Files:**
+- Create: `tests/integration/test_http_serving.py`
+
+- [ ] **Step 1:** Start an in-process HTTP app with a `Journal/*`-only profile and a known token.
+- [ ] **Step 2 (auth):** request with no/wrong token → 401; with the right token → MCP handshake succeeds.
+- [ ] **Step 3 (isolation):** via the authenticated client, exercise search, vector search, and a direct get/query for a `Work/*` page → none surface `Work/*`; a `Journal/*` query returns results.
+- [ ] **Step 4 (writes):** if not `--read-only`, a write to `Work/*` → `AccessDenied`; with `--read-only`, the write tool is not listed.
+- [ ] **Step 5:** Run: `uv run pytest tests/integration/test_http_serving.py -v` — Expected: PASS. Record outcomes; only then mark serving complete.
+- [ ] **Step 6: Commit** — `git commit -m "test(integration): end-to-end HTTP serving + profile isolation"`
+
+---
+
+## Backward Compatibility
+
+- `--transport` defaults to `stdio`; existing stdio users (and the `mcp-logseq = "mcp_logseq:main"` entry) are unchanged. Task 3 Step 4 includes a stdio smoke test as the regression guard.
+- All new behavior is opt-in via `--transport http`. No config migration; existing config files work as-is (they already define the profile/ACL).
+- New deps (`starlette`, `uvicorn`) are runtime-only; the stdio path does not import them (import them lazily inside `run_http`).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** transport (Task 1), auth (Task 2), CLI/bind (Task 3), full-surface ACL audit (Task 4), writes (Task 5), per-profile docs (Task 6), acceptance (Task 7). Covered.
+- **Reuse over rebuild:** ACL and per-profile config already exist; Tasks 4–5 *audit and extend* the existing guard rather than introduce a new one.
+- **No 0.0.0.0:** loopback default is stated in Task 3 and Task 6 — binding scope is part of the security contract.
+- **Name consistency:** `build_app()`, `create_asgi_app(auth_token)`, `run_http(host, port, auth_token)`, `BearerAuthMiddleware(token=...)`, `MCP_HTTP_AUTH_TOKEN`, `--transport/--host/--port/--read-only` used identically across tasks.
+- **[DECIDE-A/B/C]** are pinned to their dependent tasks.
+```

--- a/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
+++ b/docs/superpowers/plans/2026-06-14-http-transport-secure-serving.md
@@ -27,14 +27,42 @@ Confirmed in the current tree — the developer should reuse, not reimplement:
 
 Because the ACL globals are loaded at import time and live per-process, **running N instances with N config files needs no refactor of the ACL layer.** The work is transport + auth + a completeness audit of the network surface.
 
+**Isolation model — decided: multi-instance, not multi-tenant.** A single shared process with a runtime `token → policy` lookup was considered and rejected: it would turn a hard OS-level wall into a soft in-process lookup, require refactoring every ACL check from module globals to request-scoped policy, and make a single bug a cross-profile leak. With multi-instance, the profile boundary *is* the process boundary — another profile's config is never even loaded — so the worst case is a profile leaking its own permitted data, never another's. Profiles are few and slow-changing (e.g. local-LLM / Claude / GPT tiers), so the ops cost of N processes is trivial against the isolation gain.
+
+---
+
+## Vector DB & Sync Model (multi-instance)
+
+The vector DB is a single on-disk store shared by all reader instances. ACL controls operate on **two axes** — index-time (global, what the DB contains) vs query-time (per-instance, what a profile sees). **Do not conflate them:**
+
+- **Index-time — `vector` block, the writer's single global policy.** `vector.exclude_tags`, plus (new, Task 7) `vector.include_namespaces` / `vector.exclude_namespaces`. Decides what is ever embedded/stored. Use it for (a) content no tier may ever vector-search (e.g. `#secret` raw credentials → `exclude_tags`) and (b) namespaces irrelevant or off-limits to *everyone* (`exclude_namespaces`), or to scope the whole DB to a subset (`include_namespaces`). Anything excluded here is gone for **every** profile — and never embedded, so it also shrinks the DB (less disk, less sync compute, faster search as the vault grows).
+- **Query-time — env per instance → `_exclude_tags` / `_include_namespaces` / `_exclude_namespaces`.** Decides which profile sees which already-stored content. This is the per-tier wall.
+
+**Single writer, separated from readers (decided).** Exactly one dedicated process owns the DB — `logseq-sync --watch` (or `--once` under launchd/systemd/cron), guarded by the existing `sync.lock` ([bin/logseq_sync.py:45-60](../../../src/mcp_logseq/bin/logseq_sync.py#L45-L60)). It indexes with the **single fixed index policy** above. **No MCP instance triggers sync at all:** `sync_vector_db`'s handler no longer spawns a subprocess — it returns instructions to run `logseq-sync` externally (Task 5b). Since it is then inert (returns text, mutates nothing), `--read-only` does not special-case it. This makes "whose index policy wins" impossible: there is one writer with one policy, and all per-tier differentiation is query-time.
+
+**Gap this exposes:** `vector_search` currently filters results by namespace only, **not** by `_exclude_tags` ([index.py:49-55](../../../src/mcp_logseq/vector/index.py#L49-L55)). On the shared DB that means a profile which should exclude `#keys` would still receive `#keys` pages over HTTP. Task 4 closes this (the data is available: chunks carry `tags`, surfaced as `SearchResult.tags`).
+
+---
+
+## Profile & Config Model (decided)
+
+**Decision: one shared data/vector config file + per-instance policy via env vars — no separate sync config file, no new config-loading code.**
+
+`db_path` and `embedder` are an irreducible shared truth: the writer and every reader must agree on them (an embedder mismatch raises, [sync.py:95-99](../../../src/mcp_logseq/vector/sync.py#L95-L99)). So they live in **one** file:
+
+- **Shared `data.json`** (owned by the writer): `logseq_graph_path` + the `vector` block (`db_path`, `embedder`, index-time `exclude_tags` = never-store only, journal/chunk settings). `LOGSEQ_CONFIG_FILE` points here for the writer **and** every reader. Readers use it for `db_path`/`embedder` (open DB read-only + embed queries) and `graph_path` (informational staleness check — the *server* has graph access on the host; the sandboxed agent does not).
+- **Per-reader policy via env** (one launchd/systemd unit each): `LOGSEQ_INCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_TAGS` (query-time), `MCP_HTTP_AUTH_TOKEN`, `--port`, `--read-only`. This works because the ACL loaders already take **env over config file** ([config.py:122-127](../../../src/mcp_logseq/config.py#L122-L127)) — no merge mechanism needed.
+
+A profile is therefore "the shared data file + a unit file's env block." Adding a tier = a new unit with a few env lines and a token; the data file and DB are untouched. (A profile that prefers file-based policy can still set the root-level ACL keys in its own config file — env is just the zero-duplication default.)
+
 ---
 
 ## Scope (in / out)
 
 **In scope (vector + normal search era):**
 - HTTP/SSE transport with bearer auth and configurable bind address, selectable without breaking stdio.
-- A documented "one instance per profile" run pattern.
-- A security audit ensuring **every content-returning tool** enforces the ACL over the new HTTP surface, and a policy for write tools.
+- A documented "one instance per profile" run pattern, plus a separate single-writer `logseq-sync` process that owns the shared vector DB.
+- A security audit ensuring **every content-returning tool** enforces the ACL over the new HTTP surface (including the `vector_search` tag gap), and a policy for write tools and sync.
 
 **Out of scope (now):**
 - Vault/raw-file browsing for the client (the user will use the Logseq web app for read-only browsing).
@@ -43,11 +71,16 @@ Because the ACL globals are loaded at import time and live per-process, **runnin
 
 ---
 
-## Open Decisions (resolve before the dependent task)
+## Resolved Decisions
 
-- **[DECIDE-A] Transport flavor.** Streamable HTTP (current MCP recommendation) vs legacy SSE. Default to **Streamable HTTP**; only fall back to SSE if the pinned `mcp` version lacks it. *Dependent: Task 1.*
-- **[DECIDE-B] Auth token source.** Read the endpoint bearer token from an env var (`MCP_HTTP_AUTH_TOKEN`) and/or a config-file key. Default: env var, required when `--transport http`. *Dependent: Task 2.*
-- **[DECIDE-C] Write tools over HTTP.** Either (a) keep write tools exposed but ensure each is gated by `_enforce_namespace_access` before mutating, or (b) add a per-instance `--read-only` flag that unregisters write tools entirely. Recommended: implement **both** — (a) is the correctness floor, (b) is the simplest hard guarantee per profile. *Dependent: Task 5.*
+- **[DECIDE-A] Transport flavor — RESOLVED: Streamable HTTP.** Current MCP recommendation. Fall back to legacy SSE only if the pinned `mcp` version lacks it (confirm in Task 1 Step 1). *Task 1.*
+- **[DECIDE-B] Auth token source — RESOLVED: `MCP_HTTP_AUTH_TOKEN` env var,** required when `--transport http` (no config-file key). *Task 2.*
+- **[DECIDE-C] Write tools over HTTP — RESOLVED: implement both, least-privilege posture.**
+  - **Namespace gating on writes already exists** (PR #65) on every write tool: `create_page` ([tools.py:269](../../../src/mcp_logseq/tools.py#L269)), `delete_page` (607), `update_page` (701), block writes via `_enforce_block_namespace_access` (791/846/1918/2002), and `rename_page` checks **both** old and new name (1745-1746), which already closes the "temp page → rename into a blocked namespace" smuggling path. So Task 5 does **not** re-add namespace gating.
+  - **New work in Task 5:** (b) a per-instance `--read-only` flag that unregisters all genuine write tools (create/update/delete/rename page+block). It does **not** touch `sync_vector_db` — that handler becomes an inert "run `logseq-sync` externally" stub on every instance (Task 5b), since the DB is owned by the separate writer. Read-only tiers run `--read-only`; only tiers that need to write run writable.
+  - **Tag asymmetry on writes (recommended add):** write gating is namespace-only; reads block by tag OR namespace. A `#keys`-tagged page in an *allowed* namespace is therefore writable/deletable though unreadable. For integrity, extend `update_page`/`delete_page`/`update_block`/`delete_block`/`set_block_properties` to also deny tag-blocked targets (a fetch-then-`_is_page_excluded` check; new pages have no prior tags so `create_page` is exempt). Marked recommended — veto-able.
+
+  *Task 5.*
 
 ---
 
@@ -56,12 +89,16 @@ Because the ACL globals are loaded at import time and live per-process, **runnin
 - Create: `src/mcp_logseq/transport/__init__.py`
 - Create: `src/mcp_logseq/transport/http.py` — ASGI app wrapping the existing `Server`, bearer-auth middleware, uvicorn runner.
 - Modify: `src/mcp_logseq/server.py` — factor tool registration into an importable `build_app()` so both stdio and HTTP reuse it; add transport dispatch.
-- Modify: `src/mcp_logseq/__init__.py` — `main()` parses `--transport {stdio,http}`, `--host`, `--port`.
+- Modify: `src/mcp_logseq/__init__.py` — `main()` parses `--transport {stdio,http}`, `--host`, `--port`, `--read-only`.
+- Modify: `src/mcp_logseq/vector/index.py` — `vector_search` query-time tag filter (Task 4); `sync_vector_db` external-pointer stub (Task 5b).
+- Modify: `src/mcp_logseq/config.py` — `VectorConfig` + `load_vector_config` gain `include_namespaces`/`exclude_namespaces` (Task 7).
+- Modify: `src/mcp_logseq/vector/chunker.py` — index-time namespace filter in `chunk_file` (Task 7).
 - Modify: `pyproject.toml` — bump `mcp` to a version with Streamable HTTP; add `starlette`, `uvicorn`; (optional) `serve` console alias.
 - Create: `tests/unit/test_http_transport.py`
 - Create: `tests/integration/test_http_serving.py`
-- Modify: `tests/unit/test_namespace_access.py` — extend to assert the guard holds on every content-returning tool (Task 4).
-- Modify: `README.md` — document host-serving, the per-profile multi-instance pattern, and the security model.
+- Modify: `tests/unit/test_namespace_access.py` — extend to assert the guard holds on every content-returning tool, incl. the `vector_search` tag gap (Task 4) and `--read-only` (Task 5).
+- Modify: `tests/unit/test_chunker.py` — index-time namespace scoping (Task 7); `tests/unit/test_vector_tools.py` — `sync_vector_db` stub (Task 5b).
+- Modify: `README.md` — document host-serving, the per-profile multi-instance pattern, the separate sync writer, and the security model.
 
 ---
 
@@ -176,27 +213,40 @@ def test_wrong_token_is_401(monkeypatch):
 
 - [ ] **Step 3: Run to verify fail** — Expected: FAIL (no auth module / 404).
 
-- [ ] **Step 4: Implement `auth.py`**
+- [ ] **Step 4: Implement `auth.py` as PURE ASGI middleware**
+
+> **Do not use `starlette.middleware.base.BaseHTTPMiddleware`.** It buffers the
+> response body and is known to break streaming / SSE responses — which
+> Streamable HTTP relies on for server→client messages. A pure ASGI middleware
+> passes the send channel straight through and does not interfere with streaming.
 
 ```python
 # src/mcp_logseq/transport/auth.py
 import hmac
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
-class BearerAuthMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, token: str):
-        super().__init__(app)
+class BearerAuthMiddleware:
+    """Pure ASGI auth — streaming-safe (no BaseHTTPMiddleware buffering)."""
+    def __init__(self, app: ASGIApp, token: str) -> None:
+        self._app = app
         self._token = token
 
-    async def dispatch(self, request, call_next):
-        auth = request.headers.get("Authorization", "")
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        auth = headers.get(b"authorization", b"").decode()
         prefix = "Bearer "
         presented = auth[len(prefix):] if auth.startswith(prefix) else ""
         if not presented or not hmac.compare_digest(presented, self._token):
-            return JSONResponse({"error": "unauthorized"}, status_code=401)
-        return await call_next(request)
+            await JSONResponse({"error": "unauthorized"}, status_code=401)(scope, receive, send)
+            return
+        await self._app(scope, receive, send)
 ```
+
+`asgi.add_middleware(BearerAuthMiddleware, token=auth_token)` still works — Starlette wraps any ASGI-callable class, not just `BaseHTTPMiddleware` subclasses.
 
 - [ ] **Step 5: Run to verify pass** — Expected: PASS (both 401 tests).
 
@@ -270,27 +320,67 @@ def test_direct_get_page_denied(denied_private_profile):
 
 - [ ] **Step 4: Add `_enforce_namespace_access` / `_is_page_blocked` filtering** to each bypassing tool (mirror the existing pattern at `tools.py:1241/1382/1508`). For DSL `query`, filter the returned block list by each block's owning page.
 
+- [ ] **Step 4b (vector tag gap — REQUIRED): apply `_exclude_tags` to `vector_search`.** Today `vector_search` filters results by namespace only ([index.py:49-55](../../../src/mcp_logseq/vector/index.py#L49-L55)); on the shared DB this leaks tag-blocked pages (e.g. `#keys`) to profiles that should not see them. Add a query-time tag filter mirroring `_filter_results_by_namespace`. The data is already on each result — no API call needed:
+
+```python
+# src/mcp_logseq/vector/index.py — import _exclude_tags alongside the namespace globals
+def _filter_results_by_tags(results, exclude_tags):
+    if not exclude_tags:
+        return results
+    return [r for r in results if not any(t in exclude_tags for t in (r.tags or []))]
+
+# in run_tool, after the namespace filter:
+results = _filter_results_by_namespace(results, _include_namespaces, _exclude_namespaces)
+results = _filter_results_by_tags(results, _exclude_tags)
+```
+
+Add a failing test first: a profile with `LOGSEQ_EXCLUDE_TAGS=keys` must not surface a `#keys` chunk from `vector_search`, even though that chunk is physically in the shared DB.
+
 - [ ] **Step 5: Run to verify pass** — Expected: PASS for all enumerated tools.
 
 - [ ] **Step 6: Commit** — `git commit -m "fix(acl): enforce namespace/tag guard on all content-returning tools"`
 
-### Task 5: Write-tool policy (gated + optional read-only)
+### Task 5: Write-tool policy (`--read-only` + tag-on-write)
+
+> **Namespace gating on writes already exists** (PR #65 — see Resolved Decisions [DECIDE-C] for the per-tool line map, including `rename_page`'s dual old/new check). Do NOT re-add it. This task adds the `--read-only` flag and (recommended) closes the write-side tag asymmetry.
 
 **Files:**
-- Modify: `src/mcp_logseq/tools.py` (write handlers) and `src/mcp_logseq/__init__.py` / `server.py` (`--read-only`)
+- Modify: `src/mcp_logseq/__init__.py` / `src/mcp_logseq/server.py` (`--read-only` threaded into `build_app()`)
+- Modify: `src/mcp_logseq/tools.py` (tag check on existing-page write handlers)
 - Test: `tests/unit/test_namespace_access.py`
 
-- [ ] **Step 1: Resolve [DECIDE-C].** Confirm both (a) gate writes and (b) `--read-only`.
+- [ ] **Step 1: Regression guard for existing write gating.** Add tests asserting `create_page`/`update_block`/`set_block_properties`/`insert_nested_block`/`delete_block`/`delete_page`/`update_page` targeting `Private/*` raise `AccessDenied`, and `rename_page` denies when *either* old or new name is in `Private/*`. These should PASS already — they pin the PR #65 behavior so the `--read-only` refactor can't regress it.
 
-- [ ] **Step 2: Write failing tests** — (a) `create_page`/`update_block`/`set_block_properties`/`insert_nested_block`/`delete_block` targeting `Private/*` raise `AccessDenied`; (b) with `--read-only`, write tools are absent from `list_tools()`.
+- [ ] **Step 2: Write failing tests for the new behavior** — (a) with `--read-only`, every genuine write tool (create/update/delete/rename page+block) is absent from `list_tools()` while read tools (incl. `vector_search`, `vector_db_status`, and the inert `sync_vector_db` stub) remain; (b) [recommended] `update_page`/`delete_page`/`update_block`/`delete_block`/`set_block_properties` on a page tagged `#keys` (in an allowed namespace) raise `AccessDenied`.
 
-- [ ] **Step 3: Run to verify fail** — Expected: FAIL.
+- [ ] **Step 3: Run to verify fail** — Expected: Step 1 PASS, Step 2 FAIL.
 
-- [ ] **Step 4: Implement** — call `_enforce_namespace_access(target_page)` (and `_enforce_block_namespace_access` for block-targeted writes) at the top of each write handler; add a `--read-only` flag threaded into `build_app()` that skips registering write handlers.
+- [ ] **Step 4: Implement** — thread a `--read-only` flag into `build_app()` that skips registering the genuine write handlers (leave `sync_vector_db`, `vector_search`, `vector_db_status` registered). [Recommended] For the tag asymmetry, add a fetch-then-`_is_page_excluded` check to the existing-page write handlers (resolve the block's owning page for block writes); `create_page` is exempt (no prior tags).
 
 - [ ] **Step 5: Run to verify pass** — Expected: PASS.
 
-- [ ] **Step 6: Commit** — `git commit -m "feat(acl): gate writes by namespace + per-instance --read-only"`
+- [ ] **Step 6: Commit** — `git commit -m "feat(acl): per-instance --read-only + tag-on-write guard"`
+
+### Task 5b: Make `sync_vector_db` an inert external-sync pointer
+
+The DB is owned by the separate writer (see Vector DB & Sync Model), so no MCP instance should spawn a sync subprocess.
+
+**Files:**
+- Modify: `src/mcp_logseq/vector/index.py` (`SyncVectorDBToolHandler`)
+- Test: `tests/unit/test_vector_tools.py`
+
+- [ ] **Step 1: Write the failing test** — calling `sync_vector_db` returns text containing `logseq-sync` and does **not** invoke `subprocess.run` (patch it and assert not called).
+
+- [ ] **Step 2: Implement** — replace `run_tool`'s subprocess call with a static message; update the tool description to say sync runs externally on the host that owns the DB:
+
+```
+Vector DB sync is not available via MCP. Run it on the host that owns the DB:
+  logseq-sync --once      # incremental sync
+  logseq-sync --watch     # continuous file watcher
+  logseq-sync --rebuild   # drop and re-index everything
+```
+
+- [ ] **Step 3: Run to verify pass.** **Step 4: Commit** — `git commit -m "feat(vector): sync_vector_db points to external logseq-sync (single-writer)"`
 
 ### Task 6: Document the per-profile run pattern
 
@@ -299,27 +389,70 @@ def test_direct_get_page_denied(denied_private_profile):
 
 - [ ] **Step 1:** Document that a "profile" = one config file, and you run one instance per profile on its own port, each with its own `MCP_HTTP_AUTH_TOKEN`:
 
-````markdown
-# Journal-only profile
-LOGSEQ_CONFIG_FILE=~/.logseq/profiles/journal.json \
-MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
-mcp-logseq --transport http --port 12320
+All instances share **one** data config file (`db_path`/`embedder`/`graph_path`); each profile is just an env block + token (see Profile & Config Model). `--read-only` is a **new** capability introduced by Task 5 — these examples lean on it:
 
-# Work-only profile (separate process, separate port, separate token)
-LOGSEQ_CONFIG_FILE=~/.logseq/profiles/work.json \
+````markdown
+# "journal-assistant" — reads your diary and reflects back, but can never edit it.
+# Whole-instance read-only: no write tools at all.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Journal \
+MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
+mcp-logseq --transport http --port 12320 --read-only
+
+# "work" — full read/write within Work/, and explicitly no diary access.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Work \
+LOGSEQ_EXCLUDE_NAMESPACES=Journal \
 MCP_HTTP_AUTH_TOKEN=$WORK_TOKEN \
 mcp-logseq --transport http --port 12321
+
+# "personal" — broad read/write, but credentials stay invisible.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_EXCLUDE_TAGS=keys,secret \
+MCP_HTTP_AUTH_TOKEN=$PERSONAL_TOKEN \
+mcp-logseq --transport http --port 12322
 ````
 
-Note: each instance loads exactly one config, so namespace scoping is per-process. Bind to loopback (or a host-internal interface), never `0.0.0.0`.
+The data file is identical across all three; the per-process env block *is* the profile. The diary use case maps cleanly to whole-instance `--read-only`: `journal-assistant` reads `Journal/` and answers but holds zero write tools, while `work` excludes `Journal/` entirely. Bind to loopback (or a host-internal interface), never `0.0.0.0`.
 
-- [ ] **Step 2: Commit** — `git commit -m "docs: per-profile HTTP serving and security model"`
+- [ ] **Step 2: Document the separate sync writer.** The vector DB is owned by **one** dedicated `logseq-sync` process, deployed outside every MCP instance. It indexes with the single global index policy (`vector.exclude_tags` = secrets only, plus optional `vector.include_namespaces`/`vector.exclude_namespaces` to scope the whole DB — Task 7); per-tier differentiation is purely query-time on the reader instances. Show both deployment shapes:
+
+````markdown
+# Continuous writer (launchd / systemd unit), owns the DB — same shared data file:
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --watch
+
+# Or scheduled one-shot (cron / launchd StartInterval):
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --once
+````
+
+The writer reads no ACL env — only the `vector` block and `graph_path` from `data.json`. Its `vector.exclude_tags` (never-store only) is the sole index-time policy. Reader profiles share the same `db_path` read-only and never run sync.
+
+- [ ] **Step 3: Commit** — `git commit -m "docs: per-profile HTTP serving, separate sync writer, security model"`
+
+### Task 7: Index-time namespace scoping (writer global policy)
+
+Symmetric with the existing index-time `vector.exclude_tags`: let the writer scope what the shared DB contains by namespace, so content irrelevant or off-limits to *every* profile is never embedded (smaller DB, less sync compute, faster search). This is **global** index policy — distinct from the per-instance query-time namespace ACL.
+
+**Files:**
+- Modify: `src/mcp_logseq/config.py` (`VectorConfig` + `load_vector_config`)
+- Modify: `src/mcp_logseq/vector/chunker.py` (`chunk_file`)
+- Test: `tests/unit/test_chunker.py`
+
+- [ ] **Step 1: Write failing tests** — a `VectorConfig` with `exclude_namespaces=["Journal"]` makes `chunk_file` return `[]` for a `Journal/*` page; with `include_namespaces=["Work"]`, only `Work/*` pages produce chunks. Pages outside the scope yield no chunks.
+
+- [ ] **Step 2: Run to verify fail** — Expected: FAIL (fields/filter absent).
+
+- [ ] **Step 3: Implement** — add `include_namespaces: list[str]` / `exclude_namespaces: list[str]` to `VectorConfig` (default `[]`), parse them from the `vector` block in `load_vector_config`. In `chunk_file`, after `page_title` is derived, reuse the same allow/deny semantics as `tools._is_namespace_blocked` (exclude wins; include is a strict allow-list) and `return []` when the page's namespace is blocked — mirror the existing `exclude_tags` early-return just above it.
+
+- [ ] **Step 4: Run to verify pass.** A changed index policy requires `logseq-sync --rebuild` to take effect (note this in the README sync section); incremental sync skips unchanged files by content hash.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(vector): index-time include/exclude namespace scoping"`
 
 ---
 
 ## Phase 3 — Acceptance
 
-### Task 7: End-to-end serving + isolation
+### Task 8: End-to-end serving + isolation
 
 **Files:**
 - Create: `tests/integration/test_http_serving.py`
@@ -327,9 +460,10 @@ Note: each instance loads exactly one config, so namespace scoping is per-proces
 - [ ] **Step 1:** Start an in-process HTTP app with a `Journal/*`-only profile and a known token.
 - [ ] **Step 2 (auth):** request with no/wrong token → 401; with the right token → MCP handshake succeeds.
 - [ ] **Step 3 (isolation):** via the authenticated client, exercise search, vector search, and a direct get/query for a `Work/*` page → none surface `Work/*`; a `Journal/*` query returns results.
-- [ ] **Step 4 (writes):** if not `--read-only`, a write to `Work/*` → `AccessDenied`; with `--read-only`, the write tool is not listed.
-- [ ] **Step 5:** Run: `uv run pytest tests/integration/test_http_serving.py -v` — Expected: PASS. Record outcomes; only then mark serving complete.
-- [ ] **Step 6: Commit** — `git commit -m "test(integration): end-to-end HTTP serving + profile isolation"`
+- [ ] **Step 4 (writes):** if not `--read-only`, a write to `Work/*` → `AccessDenied`; with `--read-only`, no write tool is listed (but `sync_vector_db` stub and read tools remain).
+- [ ] **Step 5 (index scope):** with the writer configured `vector.exclude_namespaces=["Secret"]`, a `Secret/*` page is absent from `vector_search` for **all** profiles (not merely filtered).
+- [ ] **Step 6:** Run: `uv run pytest tests/integration/test_http_serving.py -v` — Expected: PASS. Record outcomes; only then mark serving complete.
+- [ ] **Step 7: Commit** — `git commit -m "test(integration): end-to-end HTTP serving + profile isolation"`
 
 ---
 
@@ -343,8 +477,12 @@ Note: each instance loads exactly one config, so namespace scoping is per-proces
 
 ## Self-Review Notes
 
-- **Spec coverage:** transport (Task 1), auth (Task 2), CLI/bind (Task 3), full-surface ACL audit (Task 4), writes (Task 5), per-profile docs (Task 6), acceptance (Task 7). Covered.
-- **Reuse over rebuild:** ACL and per-profile config already exist; Tasks 4–5 *audit and extend* the existing guard rather than introduce a new one.
+- **Spec coverage:** transport (Task 1), auth (Task 2), CLI/bind (Task 3), full-surface ACL audit incl. `vector_search` tag gap (Task 4), `--read-only` + tag-on-write (Task 5), `sync_vector_db` external-pointer stub (Task 5b), per-profile + separate-writer docs (Task 6), index-time namespace scoping (Task 7), acceptance incl. index-scope check (Task 8). Covered.
+- **Reuse over rebuild:** ACL and per-profile config already exist; Tasks 4–5 *audit and extend* the existing guard rather than introduce a new one. **Namespace gating on writes is already complete** (PR #65, incl. `rename_page` dual-endpoint) — Task 5 adds only `--read-only` and the recommended tag-on-write check, not namespace gating.
+- **Config model:** one shared data/vector config file (writer-owned) + per-reader policy via env (namespace/tags/token) — leverages existing env-over-file precedence, no merge code, no `db_path`/`embedder` drift.
+- **Isolation:** multi-instance (process boundary), not multi-tenant (runtime lookup) — decided in What ALREADY Exists / Isolation model.
+- **Sync ownership:** one dedicated writer process; reader instances are `--read-only` and never sync. The two tag controls (index-time `vector.exclude_tags` vs query-time `LOGSEQ_EXCLUDE_TAGS`) are kept distinct.
+- **Streaming safety:** auth is pure ASGI middleware, not `BaseHTTPMiddleware` (which would break SSE).
 - **No 0.0.0.0:** loopback default is stated in Task 3 and Task 6 — binding scope is part of the security contract.
 - **Name consistency:** `build_app()`, `create_asgi_app(auth_token)`, `run_http(host, port, auth_token)`, `BearerAuthMiddleware(token=...)`, `MCP_HTTP_AUTH_TOKEN`, `--transport/--host/--port/--read-only` used identically across tasks.
 - **[DECIDE-A/B/C]** are pinned to their dependent tasks.

--- a/docs/superpowers/plans/2026-06-15-index-time-namespace-scoping.md
+++ b/docs/superpowers/plans/2026-06-15-index-time-namespace-scoping.md
@@ -1,0 +1,76 @@
+# Index-Time Namespace Scoping for the Vector DB
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the vector-DB writer scope *what gets embedded at all* by namespace, via `vector.include_namespaces` / `vector.exclude_namespaces` in the config — symmetric with the existing index-time `vector.exclude_tags`. Content irrelevant or off-limits to **every** consumer is then never embedded: smaller DB, less sync compute, faster search.
+
+**Transport-independent:** This feature lives entirely in the sync writer (`config.py` + `chunker.py`), executed by the `logseq-sync` CLI. It has nothing to do with how the MCP server is reached, so it benefits **stdio and HTTP equally**. It is split out of the [secure HTTP serving plan](2026-06-14-http-transport-secure-serving.md) precisely because it stands alone.
+
+---
+
+## Two-axis model (context)
+
+ACL over the vector DB operates on two distinct axes — this feature adds the namespace dimension to the **index-time** axis, which currently only has tags:
+
+| | Index-time (writer global policy) | Query-time (per-consumer) |
+|---|---|---|
+| **Tags** | `vector.exclude_tags` (exists) | `_exclude_tags` (exists) |
+| **Namespace** | **this feature** | `_include_namespaces` / `_exclude_namespaces` (exists) |
+
+Index-time = "what the DB contains," decided once by the writer. Query-time = "what a given consumer sees," decided per request/instance. They compose: anything excluded at index time is gone for everyone; query-time differentiates within what remains.
+
+**Use cases:**
+- Whole vault is large but every consumer only cares about one area → `include_namespaces: ["Work"]` indexes only `Work/*`.
+- A namespace no consumer should ever vector-search → `exclude_namespaces: ["Secret"]` keeps it out of the DB entirely (stronger than query-time filtering, which leaves the plaintext on disk).
+
+---
+
+## What already exists (reuse, do not rebuild)
+
+- `vector.exclude_tags` index-time filtering in `chunk_file` ([chunker.py:133-135](../../../src/mcp_logseq/vector/chunker.py#L133-L135)) — the exact pattern to mirror (early `return []`).
+- `page_title` derivation incl. the `___` → `/` namespace separator ([chunker.py:87-98](../../../src/mcp_logseq/vector/chunker.py#L87-L98)).
+- `_is_namespace_blocked` allow/deny semantics (exclude wins; include is a strict allow-list) in `tools.py` — reuse the same logic so index-time and query-time behave identically. Factor the matcher into a small shared helper rather than duplicating.
+
+---
+
+## Tasks
+
+### Task 1: Config fields
+
+**Files:**
+- Modify: `src/mcp_logseq/config.py`
+- Test: `tests/unit/test_config.py`
+
+- [ ] **Step 1: Write failing tests** — `load_vector_config` returns a `VectorConfig` whose `include_namespaces` / `exclude_namespaces` reflect the `vector` block; default to `[]` when absent.
+- [ ] **Step 2: Run to verify fail.**
+- [ ] **Step 3: Implement** — add `include_namespaces: list[str] = field(default_factory=list)` and `exclude_namespaces: list[str] = field(default_factory=list)` to `VectorConfig`; parse both from `vector_raw` in `load_vector_config` (accept list or comma string, mirroring how root-level CSV configs are normalized).
+- [ ] **Step 4: Run to verify pass. Commit** — `git commit -m "feat(config): vector index-time namespace fields"`
+
+### Task 2: Chunker filter
+
+**Files:**
+- Modify: `src/mcp_logseq/vector/chunker.py`
+- (Optionally) Modify: `src/mcp_logseq/tools.py` to export the namespace matcher for reuse.
+- Test: `tests/unit/test_chunker.py`
+
+- [ ] **Step 1: Write failing tests** — with `exclude_namespaces=["Journal"]`, `chunk_file` returns `[]` for a `Journal/*` page; with `include_namespaces=["Work"]`, only `Work/*` pages produce chunks; a page outside the include list yields `[]`. Cover the `___`-encoded namespace filename form too.
+- [ ] **Step 2: Run to verify fail.**
+- [ ] **Step 3: Implement** — after `page_title` is derived in `chunk_file`, apply the shared allow/deny matcher against `config.include_namespaces` / `config.exclude_namespaces`; `return []` when blocked, right alongside the existing `exclude_tags` early-return.
+- [ ] **Step 4: Run to verify pass. Commit** — `git commit -m "feat(vector): index-time include/exclude namespace scoping"`
+
+### Task 3: Docs + rebuild note
+
+**Files:**
+- Modify: `README.md` (or the vector/config docs)
+
+- [ ] **Step 1:** Document the two new `vector` keys and the two-axis model. **Call out:** changing the index policy only takes effect on a full re-index — incremental sync skips unchanged files by content hash, so run `logseq-sync --rebuild` after editing `include_namespaces` / `exclude_namespaces`.
+- [ ] **Step 2: Commit** — `git commit -m "docs: index-time namespace scoping + rebuild note"`
+
+---
+
+## Acceptance
+
+- [ ] With `exclude_namespaces=["Secret"]`, after `--rebuild`, `vector_search` returns no `Secret/*` chunk for **any** consumer (absent from the DB, not merely filtered).
+- [ ] With `include_namespaces=["Work"]`, only `Work/*` content is searchable.
+- [ ] Empty/default config indexes everything (no behavior change for existing setups).
+- [ ] `vector_db_status` chunk/page counts drop accordingly after a scoped rebuild.

--- a/docs/superpowers/plans/2026-06-16-tls-serving-and-bind-guardrail.md
+++ b/docs/superpowers/plans/2026-06-16-tls-serving-and-bind-guardrail.md
@@ -1,0 +1,370 @@
+# TLS Serving + Insecure-Bind Guardrail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `mcp-logseq --transport http` serve directly over TLS (so the bearer token and all content are encrypted on the wire), and refuse to bind a non-loopback interface over plain HTTP unless the operator explicitly opts in — so that publishing this tool does not hand downstream users a silent footgun.
+
+**Architecture:** The HTTP transport already runs the MCP server through uvicorn (`run_http` in `src/mcp_logseq/transport/http.py`). uvicorn supports TLS natively via `ssl_certfile`/`ssl_keyfile`, so native TLS is a thin pass-through of two new CLI flags. Independently, a small validation step in the CLI entry point (`src/mcp_logseq/__init__.py`) classifies the bind host as loopback-or-not and refuses an unencrypted non-loopback bind unless `--insecure` is given. Both changes are additive and keep today's default (stdio, or plain HTTP on `127.0.0.1`) byte-for-byte unchanged. A TLS-terminating reverse proxy (e.g. Caddy) remains the recommended production path and is documented, not coded.
+
+**Tech Stack:** Python, argparse, uvicorn (`ssl_certfile`/`ssl_keyfile`), existing Starlette/MCP transport.
+
+## Global Constraints
+
+- English only — all code, comments, docs, commit messages in English.
+- Loopback bind default (`--host 127.0.0.1`) is unchanged; never default to `0.0.0.0`.
+- `uvicorn` stays a lazy import inside `run_http` (the stdio path must not import it).
+- Backward compatibility: existing `run_http(host, port, auth_token, read_only=False)` callers and the stdio path must keep working; new parameters default to "off" (`tls_cert=None`, `tls_key=None`, `insecure=False`) so current behavior is identical.
+- No new runtime dependencies — uvicorn already ships TLS support via its `standard`/stdlib `ssl` path.
+- Tests run with `LOGSEQ_API_TOKEN=test-token` in the environment (the suite imports `tools.py`, which raises at import without it). For the full suite also run `uv sync --extra vector` first.
+
+---
+
+## What ALREADY exists (reuse, do NOT rebuild)
+
+Confirmed in the current tree:
+
+- `src/mcp_logseq/__init__.py`: `parse_args(argv=None)` (argparse with `--transport`/`--host`/`--port`/`--read-only`) and `main()` which, on the http path, requires `MCP_HTTP_AUTH_TOKEN` then calls `http.run_http(args.host, args.port, token, read_only=args.read_only)`.
+- `src/mcp_logseq/transport/http.py`: `run_http(host, port, auth_token, read_only=False)` → `uvicorn.run(create_asgi_app(...), host=host, port=port)` with uvicorn imported lazily.
+- `tests/unit/test_cli.py`: existing CLI tests (parse_args defaults, http-without-token SystemExit, run_http call-through via monkeypatch). Mirror these patterns — do NOT introduce a new test style.
+
+This plan only adds flags, a validation helper, and a uvicorn pass-through. It does not touch the ASGI app, auth middleware, or ACL layer.
+
+---
+
+## File Structure
+
+- Modify: `src/mcp_logseq/transport/http.py` — `run_http` accepts `tls_cert`/`tls_key`, passes `ssl_certfile`/`ssl_keyfile` to `uvicorn.run`.
+- Modify: `src/mcp_logseq/__init__.py` — add `--tls-cert`/`--tls-key`/`--insecure` to `parse_args`; add a testable `_validate_http_options(args)` helper; call it and thread TLS into `run_http` from `main()`.
+- Modify: `tests/unit/test_cli.py` — extend with TLS pass-through, both-or-neither, and bind-guardrail tests.
+- Modify: `README.md` — TLS section (native flags + reverse-proxy), and an explicit "encrypt anything past loopback" warning.
+
+---
+
+## Resolved Decisions
+
+- **[DECIDE-A] TLS mechanism — RESOLVED: native uvicorn `ssl_certfile`/`ssl_keyfile`, plus documented reverse-proxy option.** Native TLS makes the tool self-sufficient for host-internal/self-signed encryption; a reverse proxy (Caddy, automatic Let's Encrypt) is the recommended internet-facing path and is documented in Task 3, not coded. *Tasks 1 & 3.*
+- **[DECIDE-B] Insecure-bind posture — RESOLVED: explicit `--insecure` opt-in (refuse, do not merely warn).** Binding a non-loopback host over plain HTTP raises `SystemExit` unless `--insecure` is passed. A hard refuse-with-override beats a silent warning (warnings scroll past in service logs) and beats a blanket refusal (which would break the legitimate "plain HTTP behind a TLS proxy on a private interface" setup — the operator passes `--insecure` consciously there). Loopback bind over plain HTTP needs no opt-in. TLS-configured bind on any host needs no opt-in. *Task 2.* (Veto-able: if you prefer a loud warning over a hard refuse, that is the only knob to flip.)
+- **[DECIDE-C] Loopback classification — RESOLVED: host in `{"127.0.0.1", "::1", "localhost"}` is loopback; everything else is "exposed".** This is a deliberately simple, conservative set: an operator who binds `127.0.0.2` (still loopback range) is treated as exposed and must pass TLS or `--insecure` — erring toward asking for explicit intent rather than guessing. Documented as such. *Task 2.*
+
+---
+
+## Task 1: Native TLS pass-through (`--tls-cert` / `--tls-key`)
+
+**Files:**
+- Modify: `src/mcp_logseq/transport/http.py`
+- Modify: `src/mcp_logseq/__init__.py`
+- Test: `tests/unit/test_cli.py`
+
+**Interfaces:**
+- Consumes: existing `create_asgi_app(auth_token, read_only=False)`.
+- Produces:
+  - `run_http(host: str, port: int, auth_token: str, read_only: bool = False, tls_cert: str | None = None, tls_key: str | None = None) -> None`
+  - `parse_args` namespace gains `tls_cert: str | None` and `tls_key: str | None` (default `None`).
+  - `_validate_http_options(args) -> None` in `__init__.py` (raises `SystemExit` on bad combos). Task 2 extends this same function; Task 1 only implements the TLS-pair rule.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/unit/test_cli.py`)
+
+```python
+def test_parse_args_tls_flags_default_none():
+    args = parse_args(["--transport", "http"])
+    assert args.tls_cert is None
+    assert args.tls_key is None
+
+
+def test_parse_args_tls_flags_parsed():
+    args = parse_args(
+        ["--transport", "http", "--tls-cert", "/c.pem", "--tls-key", "/k.pem"]
+    )
+    assert args.tls_cert == "/c.pem"
+    assert args.tls_key == "/k.pem"
+
+
+def test_validate_http_options_requires_both_tls_files(monkeypatch):
+    from mcp_logseq import _validate_http_options
+
+    args = parse_args(["--transport", "http", "--tls-cert", "/c.pem"])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
+def test_run_http_passes_ssl_to_uvicorn(monkeypatch):
+    import mcp_logseq.transport.http as http_mod
+
+    calls = {}
+
+    def fake_uvicorn_run(app, **kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_uvicorn_run)
+    http_mod.run_http(
+        "127.0.0.1", 12320, "tok", tls_cert="/c.pem", tls_key="/k.pem"
+    )
+    assert calls["ssl_certfile"] == "/c.pem"
+    assert calls["ssl_keyfile"] == "/k.pem"
+
+
+def test_run_http_no_tls_passes_none(monkeypatch):
+    import mcp_logseq.transport.http as http_mod
+
+    calls = {}
+    monkeypatch.setattr("uvicorn.run", lambda app, **kw: calls.update(kw))
+    http_mod.run_http("127.0.0.1", 12320, "tok")
+    assert calls.get("ssl_certfile") is None
+    assert calls.get("ssl_keyfile") is None
+```
+
+Ensure `import pytest` is present at the top of `tests/unit/test_cli.py` (add it if missing).
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `LOGSEQ_API_TOKEN=test-token uv run pytest tests/unit/test_cli.py -v`
+Expected: FAIL (`tls_cert` attribute missing / `_validate_http_options` not importable / `ssl_certfile` not passed).
+
+- [ ] **Step 3: Add the TLS flags and validation helper** in `src/mcp_logseq/__init__.py`
+
+In `parse_args`, add after the `--read-only` argument and before `return`:
+
+```python
+    p.add_argument(
+        "--tls-cert",
+        default=None,
+        help="Path to a PEM TLS certificate. Enables HTTPS (requires --tls-key).",
+    )
+    p.add_argument(
+        "--tls-key",
+        default=None,
+        help="Path to the PEM TLS private key (requires --tls-cert).",
+    )
+```
+
+Add this module-level helper (place it above `main()`):
+
+```python
+def _validate_http_options(args) -> None:
+    """Validate TLS options for the http transport. Raises SystemExit on misconfig.
+
+    Task 2 extends this with the insecure-bind guardrail.
+    """
+    import os
+
+    if (args.tls_cert is None) != (args.tls_key is None):
+        raise SystemExit("--tls-cert and --tls-key must be provided together")
+    if args.tls_cert is not None:
+        for label, path in (("--tls-cert", args.tls_cert), ("--tls-key", args.tls_key)):
+            if not os.path.isfile(path):
+                raise SystemExit(f"{label} file not found: {path}")
+```
+
+- [ ] **Step 4: Thread TLS through `main()`** — update the http branch in `src/mcp_logseq/__init__.py`
+
+```python
+    else:
+        token = os.environ.get("MCP_HTTP_AUTH_TOKEN")
+        if not token:
+            raise SystemExit("MCP_HTTP_AUTH_TOKEN is required for --transport http")
+        _validate_http_options(args)
+        from .transport import http
+
+        http.run_http(
+            args.host,
+            args.port,
+            token,
+            read_only=args.read_only,
+            tls_cert=args.tls_cert,
+            tls_key=args.tls_key,
+        )
+```
+
+- [ ] **Step 5: Pass SSL to uvicorn** in `src/mcp_logseq/transport/http.py`
+
+Replace `run_http` with:
+
+```python
+def run_http(
+    host: str,
+    port: int,
+    auth_token: str,
+    read_only: bool = False,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+) -> None:
+    """Run the HTTP transport with uvicorn (imported lazily).
+
+    When ``tls_cert``/``tls_key`` are provided, uvicorn serves over HTTPS.
+    """
+    import uvicorn
+
+    uvicorn.run(
+        create_asgi_app(auth_token, read_only=read_only),
+        host=host,
+        port=port,
+        ssl_certfile=tls_cert,
+        ssl_keyfile=tls_key,
+    )
+```
+
+- [ ] **Step 6: Run to verify pass**
+
+Run: `LOGSEQ_API_TOKEN=test-token uv run pytest tests/unit/test_cli.py -v`
+Expected: PASS (all new tests). Then full suite: `LOGSEQ_API_TOKEN=test-token uv sync --extra vector && LOGSEQ_API_TOKEN=test-token uv run pytest --tb=short` — Expected: PASS, no regression.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/mcp_logseq/transport/http.py src/mcp_logseq/__init__.py tests/unit/test_cli.py
+git commit -m "feat(transport): native TLS serving via --tls-cert/--tls-key"
+```
+
+(Use the trailer `Co-Authored-By: Claude <noreply@anthropic.com>`.)
+
+---
+
+## Task 2: Insecure-bind guardrail (`--insecure` opt-in)
+
+**Files:**
+- Modify: `src/mcp_logseq/__init__.py`
+- Test: `tests/unit/test_cli.py`
+
+**Interfaces:**
+- Consumes: `_validate_http_options(args)` from Task 1.
+- Produces: `parse_args` namespace gains `insecure: bool` (default `False`); `_validate_http_options` additionally raises `SystemExit` when binding a non-loopback host over plain HTTP without `--insecure`.
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/unit/test_cli.py`)
+
+```python
+def test_parse_args_insecure_default_false():
+    args = parse_args(["--transport", "http"])
+    assert args.insecure is False
+
+
+def test_validate_refuses_non_loopback_plain_http():
+    from mcp_logseq import _validate_http_options
+
+    args = parse_args(["--transport", "http", "--host", "0.0.0.0"])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
+def test_validate_allows_non_loopback_with_insecure():
+    from mcp_logseq import _validate_http_options
+
+    args = parse_args(["--transport", "http", "--host", "0.0.0.0", "--insecure"])
+    _validate_http_options(args)  # must not raise
+
+
+def test_validate_allows_non_loopback_with_tls(tmp_path):
+    from mcp_logseq import _validate_http_options
+
+    cert = tmp_path / "c.pem"; cert.write_text("x")
+    key = tmp_path / "k.pem"; key.write_text("x")
+    args = parse_args(
+        ["--transport", "http", "--host", "10.0.0.5",
+         "--tls-cert", str(cert), "--tls-key", str(key)]
+    )
+    _validate_http_options(args)  # must not raise
+
+
+def test_validate_allows_loopback_plain_http():
+    from mcp_logseq import _validate_http_options
+
+    for host in ("127.0.0.1", "localhost", "::1"):
+        args = parse_args(["--transport", "http", "--host", host])
+        _validate_http_options(args)  # must not raise
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `LOGSEQ_API_TOKEN=test-token uv run pytest tests/unit/test_cli.py -k "insecure or non_loopback or loopback_plain" -v`
+Expected: FAIL (`insecure` attribute missing / no guardrail raise).
+
+- [ ] **Step 3: Add `--insecure` flag** in `parse_args` (after `--tls-key`)
+
+```python
+    p.add_argument(
+        "--insecure",
+        action="store_true",
+        help=(
+            "Allow binding a non-loopback host over plain HTTP. Without TLS the "
+            "bearer token and all content travel unencrypted — only use on a "
+            "trusted network or behind a TLS-terminating reverse proxy."
+        ),
+    )
+```
+
+- [ ] **Step 4: Extend `_validate_http_options`** — add the guardrail after the TLS-file checks from Task 1
+
+```python
+    _LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+    tls_enabled = args.tls_cert is not None
+    if args.host not in _LOOPBACK_HOSTS and not tls_enabled and not args.insecure:
+        raise SystemExit(
+            f"Refusing to bind {args.host} over plain HTTP: the bearer token and "
+            f"all content would travel unencrypted. Either provide --tls-cert/"
+            f"--tls-key, put a TLS-terminating reverse proxy in front and bind a "
+            f"loopback address, or pass --insecure to override (not recommended "
+            f"outside a trusted network)."
+        )
+```
+
+Define `_LOOPBACK_HOSTS` at module level (top of `__init__.py`) rather than inside the function if you prefer; either is acceptable as long as the helper reads it. Keep the whole helper in one place.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `LOGSEQ_API_TOKEN=test-token uv run pytest tests/unit/test_cli.py -v`
+Expected: PASS. Then full suite: `LOGSEQ_API_TOKEN=test-token uv run pytest --tb=short` — Expected: PASS, no regression. Also smoke-test the default still works: `LOGSEQ_API_TOKEN=test-token MCP_HTTP_AUTH_TOKEN=x` is NOT needed here — instead assert via the tests above; do not start a real server.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mcp_logseq/__init__.py tests/unit/test_cli.py
+git commit -m "feat(cli): refuse non-loopback plain-HTTP bind without --insecure"
+```
+
+(Use the `Co-Authored-By` trailer.)
+
+---
+
+## Task 3: Document TLS and the bind guardrail
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a "TLS / encrypted serving" subsection** under the existing "Serving over HTTP" section. Read the current README first to match heading style and the existing profile examples. Document, accurately to the code in Tasks 1-2:
+
+  - Native TLS: `mcp-logseq --transport http --port 12320 --tls-cert /path/cert.pem --tls-key /path/key.pem`. Both flags are required together. Mention obtaining a cert (`mkcert`/self-signed for host-internal, Let's Encrypt for public DNS).
+  - The bind guardrail: binding a non-loopback host (anything other than `127.0.0.1`/`localhost`/`::1`) over plain HTTP is refused; the operator must supply TLS or pass `--insecure` to consciously accept an unencrypted bind (only sane behind a TLS-terminating proxy on a trusted network).
+  - Recommended production path: a reverse proxy (Caddy with automatic HTTPS) terminating TLS in front of a loopback-bound `mcp-logseq`. Show a minimal Caddy example:
+
+````markdown
+# Caddyfile — automatic HTTPS in front of a loopback-bound instance
+logseq.example.com {
+    reverse_proxy 127.0.0.1:12320
+}
+````
+
+  - One explicit security sentence: the bearer token and all content are plaintext over plain HTTP, so anything past loopback must be encrypted (native TLS or a TLS proxy).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: TLS serving, reverse-proxy guidance, insecure-bind guardrail"
+```
+
+(Use the `Co-Authored-By` trailer.)
+
+---
+
+## Backward Compatibility
+
+- All new flags default to off; `parse_args([])` and the stdio path are unchanged.
+- `run_http`'s new `tls_cert`/`tls_key` default to `None`, so `uvicorn.run(..., ssl_certfile=None, ssl_keyfile=None)` is exactly today's plain-HTTP behavior; existing callers pass nothing new.
+- A plain `--transport http --port N` on the default loopback host still starts with no TLS and no opt-in required — only non-loopback binds change behavior.
+
+## Self-Review Notes
+
+- **Spec coverage:** native TLS (Task 1), insecure-bind guardrail (Task 2), docs incl. reverse proxy (Task 3). Covered.
+- **Reuse over rebuild:** extends `run_http` and `parse_args`/`main`; no new transport, no ASGI/auth/ACL changes.
+- **Name consistency:** `_validate_http_options(args)`, `run_http(..., tls_cert, tls_key)`, flags `--tls-cert`/`--tls-key`/`--insecure`, `_LOOPBACK_HOSTS` used identically across tasks.
+- **No 0.0.0.0 default; loopback unchanged.** The guardrail makes an unencrypted exposed bind an explicit, conscious act.
+- **[DECIDE-A/B/C]** pinned to their tasks; DECIDE-B is the only veto-able knob (hard-refuse vs warn).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Text Processing",
 ]
 dependencies = [
- "mcp>=1.9.0",
+ "mcp>=1.27",
  "python-dotenv>=1.0.1",
  "requests>=2.32.3",
  "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,12 @@ classifiers = [
     "Topic :: Text Processing",
 ]
 dependencies = [
- "mcp>=1.1.0",
+ "mcp>=1.9.0",
  "python-dotenv>=1.0.1",
  "requests>=2.32.3",
  "pyyaml>=6.0",
+ "starlette>=0.37",
+ "uvicorn>=0.30",
 ]
 
 [project.urls]

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -1,9 +1,37 @@
-from . import server
-import asyncio
+def parse_args(argv=None):
+    """Build the CLI argument parser and parse ``argv``.
+
+    Exposed separately so it can be unit-tested in isolation.
+    """
+    import argparse
+
+    p = argparse.ArgumentParser(prog="mcp-logseq")
+    p.add_argument("--transport", choices=["stdio", "http"], default="stdio")
+    # Loopback default; never bind to 0.0.0.0 implicitly.
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=12320)
+    return p.parse_args(argv)
+
 
 def main():
     """Main entry point for the package."""
-    asyncio.run(server.main())
+    import os
+
+    args = parse_args()
+    if args.transport == "stdio":
+        import asyncio
+
+        from . import server
+
+        asyncio.run(server.main())
+    else:
+        token = os.environ.get("MCP_HTTP_AUTH_TOKEN")
+        if not token:
+            raise SystemExit("MCP_HTTP_AUTH_TOKEN is required for --transport http")
+        from .transport import http
+
+        http.run_http(args.host, args.port, token)
+
 
 # Optionally expose other important items at package level
-__all__ = ['main', 'server']
+__all__ = ['main', 'parse_args', 'server']

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -10,6 +10,11 @@ def parse_args(argv=None):
     # Loopback default; never bind to 0.0.0.0 implicitly.
     p.add_argument("--host", default="127.0.0.1")
     p.add_argument("--port", type=int, default=12320)
+    p.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Disable write tools (create/update/delete/rename for pages and blocks).",
+    )
     return p.parse_args(argv)
 
 
@@ -23,14 +28,14 @@ def main():
 
         from . import server
 
-        asyncio.run(server.main())
+        asyncio.run(server.main(read_only=args.read_only))
     else:
         token = os.environ.get("MCP_HTTP_AUTH_TOKEN")
         if not token:
             raise SystemExit("MCP_HTTP_AUTH_TOKEN is required for --transport http")
         from .transport import http
 
-        http.run_http(args.host, args.port, token)
+        http.run_http(args.host, args.port, token, read_only=args.read_only)
 
 
 # Optionally expose other important items at package level.

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -33,5 +33,9 @@ def main():
         http.run_http(args.host, args.port, token)
 
 
-# Optionally expose other important items at package level
-__all__ = ['main', 'parse_args', 'server']
+# Optionally expose other important items at package level.
+# ``server`` is intentionally NOT listed: it's imported lazily inside ``main``
+# (eager import would trigger server.py's import-time LOGSEQ_API_TOKEN raise on
+# the http path). Submodule access via ``from mcp_logseq.server import ...``
+# still works.
+__all__ = ['main', 'parse_args']

--- a/src/mcp_logseq/bin/logseq_sync.py
+++ b/src/mcp_logseq/bin/logseq_sync.py
@@ -10,8 +10,8 @@ Usage:
 Requires LOGSEQ_CONFIG_FILE env var pointing to a config JSON file
 with vector.enabled set to true.
 
-This CLI is the single writer for the vector DB. The MCP server delegates
-all sync operations here via subprocess to enforce the single-writer principle.
+This CLI is the sole writer for the vector DB. MCP server instances never
+invoke it; operators run it externally (or via a system unit / scheduler).
 """
 
 from __future__ import annotations

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -113,8 +113,12 @@ def _register_all_tool_handlers(handlers: dict) -> None:
         logger.warning(f"Could not load vector config, vector tools disabled: {e}")
 
 
-def build_app(read_only: bool = False) -> Server:
-    """Build a fully wired MCP ``Server`` with all tool handlers registered.
+def build_app(read_only: bool = False) -> tuple[Server, dict]:
+    """Build a fully wired MCP ``Server`` plus its tool-handler registry.
+
+    Returns ``(server, handlers)`` where ``handlers`` is the very same dict the
+    server's ``list_tools`` / ``call_tool`` closures read from. Mutating that
+    dict after construction is therefore reflected by the served app.
 
     ``read_only`` is accepted for forward compatibility (Task 5 will use it to
     skip write tools); it is currently ignored and all tools are registered.
@@ -156,24 +160,22 @@ def build_app(read_only: bool = False) -> Server:
             logger.error(f"Error running tool: {str(e)}", exc_info=True)
             raise RuntimeError(f"Error: {str(e)}")
 
-    return server
+    return server, handlers
 
 
 # ---------------------------------------------------------------------------
 # Backward-compatible module-level surface.
 #
 # Existing code/tests import ``app``, ``tool_handlers``, ``add_tool_handler``
-# and ``get_tool_handler`` from this module. Keep them working by exposing a
-# module-level Server plus its registry.
+# and ``get_tool_handler`` from this module. The module-level ``tool_handlers``
+# IS the dict that ``app``'s closures serve from — registration happens exactly
+# once — so ``add_tool_handler(X)`` after import is visible through ``app``.
 # ---------------------------------------------------------------------------
 
-app = build_app()
-tool_handlers: dict = {}
-_register_all_tool_handlers(tool_handlers)
+app, tool_handlers = build_app()
 
 
 def add_tool_handler(tool_class: tools.ToolHandler):
-    global tool_handlers
     logger.debug(f"Registering tool handler: {tool_class.name}")
     tool_handlers[tool_class.name] = tool_class
     logger.info(f"Successfully registered tool handler: {tool_class.name}")
@@ -193,7 +195,7 @@ async def main():
     logger.info("Starting LogSeq MCP server")
     from mcp.server.stdio import stdio_server
 
-    app = build_app()
+    app, _ = build_app()
     async with stdio_server() as (read_stream, write_stream):
         logger.info("Initializing server...")
         await app.run(read_stream, write_stream, app.create_initialization_options())

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -54,19 +54,44 @@ else:
 api_url = os.getenv("LOGSEQ_API_URL", "http://localhost:12315")
 logger.info(f"Using API URL: {api_url}")
 
-def _register_all_tool_handlers(handlers: dict) -> None:
+# Names of the genuine write tools — tools that mutate Logseq content. When
+# ``read_only`` is set these are NOT registered. ``sync_vector_db`` is NOT in
+# this set: it mutates the (local) vector index, not Logseq content, and stays
+# registered (Task 5b makes it inert under read-only).
+_WRITE_TOOL_NAMES = frozenset(
+    {
+        "create_page",
+        "update_page",
+        "delete_page",
+        "rename_page",
+        "update_block",
+        "delete_block",
+        "insert_nested_block",
+        "set_block_properties",
+    }
+)
+
+
+def _register_all_tool_handlers(handlers: dict, read_only: bool = False) -> None:
     """Populate ``handlers`` with every available ToolHandler instance.
 
     Mutates the provided dict in place so callers can wire ``list_tools`` /
     ``call_tool`` closures over the same registry.
+
+    When ``read_only`` is True, the genuine write handlers (see
+    ``_WRITE_TOOL_NAMES``) are skipped; all read tools plus ``sync_vector_db``,
+    ``vector_search`` and ``vector_db_status`` remain registered.
     """
 
     def add(tool_class: tools.ToolHandler) -> None:
+        if read_only and tool_class.name in _WRITE_TOOL_NAMES:
+            logger.info(f"read_only: skipping write tool handler: {tool_class.name}")
+            return
         logger.debug(f"Registering tool handler: {tool_class.name}")
         handlers[tool_class.name] = tool_class
         logger.info(f"Successfully registered tool handler: {tool_class.name}")
 
-    logger.info("Registering tool handlers...")
+    logger.info(f"Registering tool handlers (read_only={read_only})...")
 
     add(tools.CreatePageToolHandler())
     add(tools.UpdatePageToolHandler())
@@ -120,12 +145,14 @@ def build_app(read_only: bool = False) -> tuple[Server, dict]:
     server's ``list_tools`` / ``call_tool`` closures read from. Mutating that
     dict after construction is therefore reflected by the served app.
 
-    ``read_only`` is accepted for forward compatibility (Task 5 will use it to
-    skip write tools); it is currently ignored and all tools are registered.
+    When ``read_only`` is True the genuine write tools are not registered, so
+    the served app exposes only read/search tools (plus the vector tools,
+    including ``sync_vector_db``). Default ``read_only=False`` registers
+    everything, identical to prior behavior.
     """
     server = Server("mcp-logseq")
     handlers: dict = {}
-    _register_all_tool_handlers(handlers)
+    _register_all_tool_handlers(handlers, read_only)
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
@@ -191,11 +218,11 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
     return handler
 
 
-async def main():
-    logger.info("Starting LogSeq MCP server")
+async def main(read_only: bool = False):
+    logger.info(f"Starting LogSeq MCP server (read_only={read_only})")
     from mcp.server.stdio import stdio_server
 
-    app, _ = build_app()
+    app, _ = build_app(read_only=read_only)
     async with stdio_server() as (read_stream, write_stream):
         logger.info("Initializing server...")
         await app.run(read_stream, write_stream, app.create_initialization_options())

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -54,9 +54,122 @@ else:
 api_url = os.getenv("LOGSEQ_API_URL", "http://localhost:12315")
 logger.info(f"Using API URL: {api_url}")
 
-app = Server("mcp-logseq")
+def _register_all_tool_handlers(handlers: dict) -> None:
+    """Populate ``handlers`` with every available ToolHandler instance.
 
-tool_handlers = {}
+    Mutates the provided dict in place so callers can wire ``list_tools`` /
+    ``call_tool`` closures over the same registry.
+    """
+
+    def add(tool_class: tools.ToolHandler) -> None:
+        logger.debug(f"Registering tool handler: {tool_class.name}")
+        handlers[tool_class.name] = tool_class
+        logger.info(f"Successfully registered tool handler: {tool_class.name}")
+
+    logger.info("Registering tool handlers...")
+
+    add(tools.CreatePageToolHandler())
+    add(tools.UpdatePageToolHandler())
+    add(tools.ListPagesToolHandler())
+    add(tools.GetPageContentToolHandler())
+    add(tools.DeletePageToolHandler())
+    add(tools.DeleteBlockToolHandler())
+    add(tools.UpdateBlockToolHandler())
+    add(tools.GetBlockToolHandler())
+    add(tools.SearchToolHandler())
+    add(tools.QueryToolHandler())
+    add(tools.FindPagesByPropertyToolHandler())
+    add(tools.GetPagesFromNamespaceToolHandler())
+    add(tools.GetPagesTreeFromNamespaceToolHandler())
+    add(tools.RenamePageToolHandler())
+    add(tools.GetPageBacklinksToolHandler())
+    add(tools.InsertNestedBlockToolHandler())
+    add(tools.SetBlockPropertiesToolHandler())
+    logger.info("Tool handlers registration complete")
+
+    # Conditional vector tool registration — only when LOGSEQ_CONFIG_FILE is set
+    # and vector.enabled is true in the config file
+    try:
+        from .config import load_vector_config, load_exclude_tags
+        vector_config = load_vector_config()
+        # Merge top-level exclude_tags into vector config (additive union)
+        top_level_exclude = load_exclude_tags()
+        if vector_config and top_level_exclude:
+            merged = list(dict.fromkeys(top_level_exclude + vector_config.exclude_tags))
+            vector_config.exclude_tags = merged
+        if vector_config and vector_config.enabled:
+            from .vector.index import (
+                VectorDBStatusToolHandler,
+                VectorSearchToolHandler,
+                SyncVectorDBToolHandler,
+            )
+            add(VectorSearchToolHandler(vector_config))
+            add(SyncVectorDBToolHandler(vector_config))
+            add(VectorDBStatusToolHandler(vector_config))
+            logger.info("Vector search tools registered (3 tools)")
+        else:
+            logger.debug("Vector search not configured — skipping vector tools")
+    except Exception as e:
+        logger.warning(f"Could not load vector config, vector tools disabled: {e}")
+
+
+def build_app(read_only: bool = False) -> Server:
+    """Build a fully wired MCP ``Server`` with all tool handlers registered.
+
+    ``read_only`` is accepted for forward compatibility (Task 5 will use it to
+    skip write tools); it is currently ignored and all tools are registered.
+    """
+    server = Server("mcp-logseq")
+    handlers: dict = {}
+    _register_all_tool_handlers(handlers)
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        """List available tools."""
+        logger.debug("Listing tools")
+        tools_list = [th.get_tool_description() for th in handlers.values()]
+        logger.debug(f"Found {len(tools_list)} tools")
+        return tools_list
+
+    @server.call_tool()
+    async def call_tool(
+        name: str, arguments: Any
+    ) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
+        """Handle tool calls."""
+        logger.info(f"Tool call: {name} with arguments {arguments}")
+
+        if not isinstance(arguments, dict):
+            logger.error("Arguments must be dictionary")
+            raise RuntimeError("arguments must be dictionary")
+
+        tool_handler = handlers.get(name)
+        if not tool_handler:
+            logger.error(f"Unknown tool: {name}")
+            raise ValueError(f"Unknown tool: {name}")
+
+        try:
+            logger.debug(f"Running tool {name}")
+            result = await asyncio.to_thread(tool_handler.run_tool, arguments)
+            logger.debug(f"Tool result: {result}")
+            return result
+        except Exception as e:
+            logger.error(f"Error running tool: {str(e)}", exc_info=True)
+            raise RuntimeError(f"Error: {str(e)}")
+
+    return server
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible module-level surface.
+#
+# Existing code/tests import ``app``, ``tool_handlers``, ``add_tool_handler``
+# and ``get_tool_handler`` from this module. Keep them working by exposing a
+# module-level Server plus its registry.
+# ---------------------------------------------------------------------------
+
+app = build_app()
+tool_handlers: dict = {}
+_register_all_tool_handlers(tool_handlers)
 
 
 def add_tool_handler(tool_class: tools.ToolHandler):
@@ -76,93 +189,11 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
     return handler
 
 
-# Register all tool handlers
-logger.info("Registering tool handlers...")
-
-add_tool_handler(tools.CreatePageToolHandler())
-add_tool_handler(tools.UpdatePageToolHandler())
-add_tool_handler(tools.ListPagesToolHandler())
-add_tool_handler(tools.GetPageContentToolHandler())
-add_tool_handler(tools.DeletePageToolHandler())
-add_tool_handler(tools.DeleteBlockToolHandler())
-add_tool_handler(tools.UpdateBlockToolHandler())
-add_tool_handler(tools.GetBlockToolHandler())
-add_tool_handler(tools.SearchToolHandler())
-add_tool_handler(tools.QueryToolHandler())
-add_tool_handler(tools.FindPagesByPropertyToolHandler())
-add_tool_handler(tools.GetPagesFromNamespaceToolHandler())
-add_tool_handler(tools.GetPagesTreeFromNamespaceToolHandler())
-add_tool_handler(tools.RenamePageToolHandler())
-add_tool_handler(tools.GetPageBacklinksToolHandler())
-add_tool_handler(tools.InsertNestedBlockToolHandler())
-add_tool_handler(tools.SetBlockPropertiesToolHandler())
-logger.info("Tool handlers registration complete")
-
-# Conditional vector tool registration — only when LOGSEQ_CONFIG_FILE is set
-# and vector.enabled is true in the config file
-try:
-    from .config import load_vector_config, load_exclude_tags
-    vector_config = load_vector_config()
-    # Merge top-level exclude_tags into vector config (additive union)
-    top_level_exclude = load_exclude_tags()
-    if vector_config and top_level_exclude:
-        merged = list(dict.fromkeys(top_level_exclude + vector_config.exclude_tags))
-        vector_config.exclude_tags = merged
-    if vector_config and vector_config.enabled:
-        from .vector.index import (
-            VectorDBStatusToolHandler,
-            VectorSearchToolHandler,
-            SyncVectorDBToolHandler,
-        )
-        add_tool_handler(VectorSearchToolHandler(vector_config))
-        add_tool_handler(SyncVectorDBToolHandler(vector_config))
-        add_tool_handler(VectorDBStatusToolHandler(vector_config))
-        logger.info("Vector search tools registered (3 tools)")
-    else:
-        logger.debug("Vector search not configured — skipping vector tools")
-except Exception as e:
-    logger.warning(f"Could not load vector config, vector tools disabled: {e}")
-
-
-@app.list_tools()
-async def list_tools() -> list[Tool]:
-    """List available tools."""
-    logger.debug("Listing tools")
-    tools_list = [th.get_tool_description() for th in tool_handlers.values()]
-    logger.debug(f"Found {len(tools_list)} tools")
-    return tools_list
-
-
-@app.call_tool()
-async def call_tool(
-    name: str, arguments: Any
-) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
-    """Handle tool calls."""
-    logger.info(f"Tool call: {name} with arguments {arguments}")
-
-    if not isinstance(arguments, dict):
-        logger.error("Arguments must be dictionary")
-        raise RuntimeError("arguments must be dictionary")
-
-    tool_handler = get_tool_handler(name)
-    if not tool_handler:
-        logger.error(f"Unknown tool: {name}")
-        raise ValueError(f"Unknown tool: {name}")
-
-    try:
-        logger.debug(f"Running tool {name}")
-        result = await asyncio.to_thread(tool_handler.run_tool, arguments)
-        logger.debug(f"Tool result: {result}")
-        return result
-    except Exception as e:
-        logger.error(f"Error running tool: {str(e)}", exc_info=True)
-        raise RuntimeError(f"Error: {str(e)}")
-
-
 async def main():
     logger.info("Starting LogSeq MCP server")
     from mcp.server.stdio import stdio_server
 
+    app = build_app()
     async with stdio_server() as (read_stream, write_stream):
         logger.info("Initializing server...")
         await app.run(read_stream, write_stream, app.create_initialization_options())

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -179,6 +179,49 @@ def _enforce_block_namespace_access(api, block_uuid: str) -> None:
     _enforce_namespace_access(page_name)
 
 
+def _enforce_page_tag_access(api, page_name: str) -> None:
+    """Raise AccessDenied if an EXISTING page carries an excluded tag.
+
+    Complements the name-based namespace check on write handlers: namespace
+    rules can be evaluated from the name alone, but tag exclusion requires the
+    page's properties, so this fetches the page. A no-op when no exclude tags
+    are configured. Pages that cannot be fetched are treated as not-excluded
+    (the namespace check has already run, and a missing page is handled by the
+    underlying write call).
+    """
+    if not _exclude_tags:
+        return
+    try:
+        result = api.get_page_content(page_name)
+    except Exception as e:
+        logger.warning(
+            f"Could not fetch page '{page_name}' for tag-exclusion check: {e}"
+        )
+        return
+    if result and _is_page_excluded(result.get("page", {}), _exclude_tags):
+        raise AccessDenied(
+            f"Access denied: page '{page_name}' is restricted "
+            f"and cannot be accessed by this assistant."
+        )
+
+
+def _enforce_block_tag_access(api, block_uuid: str) -> None:
+    """Resolve a block's owning page and enforce tag exclusion on it.
+
+    A no-op when no exclude tags are configured. When tags ARE configured but
+    the owning page cannot be resolved, access is denied (fail-closed), mirroring
+    ``_enforce_block_namespace_access``.
+    """
+    if not _exclude_tags:
+        return
+    page_name = api.get_block_page_name(block_uuid)
+    if page_name is None:
+        raise AccessDenied(
+            f"Access denied: cannot verify the owning page of block '{block_uuid}'."
+        )
+    _enforce_page_tag_access(api, page_name)
+
+
 class ToolHandler:
     def __init__(self, tool_name: str):
         self.name = tool_name
@@ -608,6 +651,7 @@ class DeletePageToolHandler(ToolHandler):
 
         try:
             api = _make_api()
+            _enforce_page_tag_access(api, args["page_name"])
             result = api.delete_page(args["page_name"])
 
             # Build detailed success message
@@ -626,6 +670,8 @@ class DeletePageToolHandler(ToolHandler):
             )
 
             return [TextContent(type="text", text=success_msg)]
+        except AccessDenied:
+            raise
         except ValueError as e:
             # Handle validation errors (page not found) gracefully
             return [TextContent(type="text", text=f"❌ Error: {str(e)}")]
@@ -711,6 +757,7 @@ YAML frontmatter in content will be merged with explicit properties.""",
 
         try:
             api = _make_api()
+            _enforce_page_tag_access(api, page_name)
 
             # Parse the content
             parsed = (
@@ -749,6 +796,8 @@ YAML frontmatter in content will be merged with explicit properties.""",
             msg_parts.append(f"Mode: {mode}")
 
             return [TextContent(type="text", text="\n".join(msg_parts))]
+        except AccessDenied:
+            raise
         except ValueError as e:
             return [TextContent(type="text", text=f"Error: {str(e)}")]
         except Exception as e:
@@ -789,6 +838,7 @@ class DeleteBlockToolHandler(ToolHandler):
         try:
             api = _make_api()
             _enforce_block_namespace_access(api, block_uuid)
+            _enforce_block_tag_access(api, block_uuid)
             api.delete_block(block_uuid)
 
             return [TextContent(
@@ -844,6 +894,7 @@ class UpdateBlockToolHandler(ToolHandler):
         try:
             api = _make_api()
             _enforce_block_namespace_access(api, block_uuid)
+            _enforce_block_tag_access(api, block_uuid)
             api.update_block(block_uuid, content)
 
             return [TextContent(
@@ -2043,6 +2094,7 @@ class SetBlockPropertiesToolHandler(ToolHandler):
         try:
             api = _make_api()
             _enforce_block_namespace_access(api, block_uuid)
+            _enforce_block_tag_access(api, block_uuid)
             results = []
 
             for prop_name, value in properties.items():

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1061,7 +1061,9 @@ class SearchToolHandler(ToolHandler):
         """Return lowercased names of pages blocked by tag or namespace rules.
 
         Makes one extra api.list_pages() call when any rule is configured.
-        Fails open on error to avoid breaking search entirely.
+        Fail-closed: when rules are active but the page list cannot be built,
+        the error propagates so the caller aborts rather than returning an empty
+        (degraded) exclusion set that would let restricted content through.
         """
         if not exclude_tags and not exclude_namespaces and not include_namespaces:
             return set()
@@ -1077,9 +1079,15 @@ class SearchToolHandler(ToolHandler):
                 ):
                     blocked.add(name.lower())
             return blocked
-        except Exception as e:
-            logger.warning(f"Could not build blocked page names for search filtering: {e}")
-            return set()
+        except Exception:
+            # Rules are active here (guarded above), so we cannot determine what
+            # to exclude. Fail-closed: re-raise so the search handler returns an
+            # error instead of unfiltered results.
+            logger.warning(
+                "Could not build blocked page names while ACL rules are active; "
+                "failing closed (search will error rather than leak)."
+            )
+            raise
 
     @staticmethod
     def _filter_db_block_results(
@@ -1092,16 +1100,15 @@ class SearchToolHandler(ToolHandler):
         DB-mode blocks carry a 'page' field = the owning page's UUID, so the
         owning page can be resolved to a name and checked against
         ``excluded_page_names`` (which already encodes BOTH tag and namespace
-        exclusions). Fail-closed: when any exclusion rule is active and a block's
-        owning page cannot be resolved, the block is dropped.
+        exclusions). Fail-closed: when ``excluded_page_names`` is non-empty and a
+        block's owning page cannot be resolved, the block is dropped.
 
-        When no exclusion rule is active this is a no-op (no API calls).
+        A non-empty ``excluded_page_names`` is authoritative: because
+        ``_build_excluded_page_names`` fails closed when rules are active, an
+        empty set genuinely means no active exclusions, so this is a no-op
+        (no API calls) in that case.
         """
-        any_rule_active = bool(
-            excluded_page_names or _exclude_tags
-            or _include_namespaces or _exclude_namespaces
-        )
-        if not any_rule_active:
+        if not excluded_page_names:
             return block_results
 
         page_uuids = [
@@ -1463,22 +1470,35 @@ class QueryToolHandler(ToolHandler):
             return api.get_block_page_name(uuid)
         return None
 
-    def _block_blocked(self, item: dict, api) -> bool:
+    def _block_blocked(self, item: dict, api, cache: dict | None = None) -> bool:
         """Fail-closed tag AND namespace check for a DSL block result.
 
         Consulted whenever ANY rule (tag or namespace) is configured. The owning
         page is resolved once via ``_block_page_name``; the block is dropped if
         that page is namespace-blocked OR tag-excluded. A block whose owning page
         cannot be resolved is treated as blocked (fail-closed).
+
+        ``cache`` is an optional per-request memo (page name -> blocked bool) so
+        that many blocks sharing an owning page incur the tag fetch only once.
         """
         page_name = self._block_page_name(item, api)
         if page_name is None:
             return True
+        if cache is not None and page_name in cache:
+            return cache[page_name]
+
+        blocked = self._page_name_blocked(page_name, api)
+        if cache is not None:
+            cache[page_name] = blocked
+        return blocked
+
+    def _page_name_blocked(self, page_name: str, api) -> bool:
+        """Tag OR namespace block decision for an already-resolved page name."""
         if _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces):
             return True
         if _exclude_tags:
-            # Tag exclusion needs the page's properties; resolve the owning page
-            # once and inspect its tags. Fail-closed if it cannot be fetched.
+            # Tag exclusion needs the page's properties; fetch the owning page
+            # and inspect its tags. Fail-closed if it cannot be fetched.
             try:
                 page = api.get_page_content(page_name)
             except Exception:
@@ -1547,13 +1567,16 @@ class QueryToolHandler(ToolHandler):
             # (unresolvable owning page => dropped).
             if _exclude_tags or _include_namespaces or _exclude_namespaces:
                 filtered = []
+                # Per-request memo so blocks sharing an owning page only trigger
+                # one tag/namespace resolution + fetch.
+                block_decision_cache: dict[str, bool] = {}
                 for item in filtered_results:
                     if self._is_page(item):
                         name = item.get("originalName") or item.get("name", "")
                         if _is_page_blocked(item, name):
                             continue
                     elif self._is_block(item):
-                        if self._block_blocked(item, api):
+                        if self._block_blocked(item, api, block_decision_cache):
                             continue
                     filtered.append(item)
                 filtered_results = filtered

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1340,6 +1340,11 @@ class QueryToolHandler(ToolHandler):
             if name:
                 return name
         elif isinstance(page_ref, str) and page_ref:
+            # A bare UUID string is NOT a trustworthy page name: under an
+            # exclude-only policy a UUID matches no rule and would fail OPEN.
+            # Resolve the page UUID to its real name so it's fail-closed.
+            if _UUID_REF_PATTERN.fullmatch(f"[[{page_ref}]]"):
+                return api.resolve_page_uuids([page_ref]).get(page_ref)
             return page_ref
         uuid = item.get("uuid")
         if uuid:

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1082,10 +1082,51 @@ class SearchToolHandler(ToolHandler):
             return set()
 
     @staticmethod
+    def _filter_db_block_results(
+        block_results: list[dict],
+        api,
+        excluded_page_names: set[str],
+    ) -> list[dict]:
+        """Drop DB-mode content blocks whose owning page is excluded.
+
+        DB-mode blocks carry a 'page' field = the owning page's UUID, so the
+        owning page can be resolved to a name and checked against
+        ``excluded_page_names`` (which already encodes BOTH tag and namespace
+        exclusions). Fail-closed: when any exclusion rule is active and a block's
+        owning page cannot be resolved, the block is dropped.
+
+        When no exclusion rule is active this is a no-op (no API calls).
+        """
+        any_rule_active = bool(
+            excluded_page_names or _exclude_tags
+            or _include_namespaces or _exclude_namespaces
+        )
+        if not any_rule_active:
+            return block_results
+
+        page_uuids = [
+            str(b.get("page")) for b in block_results if b.get("page")
+        ]
+        resolved = api.resolve_page_uuids(page_uuids) if page_uuids else {}
+
+        kept: list[dict] = []
+        for block in block_results:
+            page_uuid = block.get("page")
+            page_name = resolved.get(str(page_uuid)) if page_uuid else None
+            if page_name is None:
+                # Fail-closed: owning page unresolvable while a rule is active.
+                continue
+            if page_name.lower() in excluded_page_names:
+                continue
+            kept.append(block)
+        return kept
+
+    @staticmethod
     def _format_db_mode_results(
         result: dict, limit: int,
         include_blocks: bool, include_pages: bool, include_files: bool,
         excluded_page_names: set[str] = frozenset(),
+        api=None,
     ) -> list[str]:
         """Format search results from DB-mode Logseq.
 
@@ -1099,6 +1140,9 @@ class SearchToolHandler(ToolHandler):
         # Split into pages and content blocks
         page_results = [b for b in blocks if b.get("page?")]
         block_results = [b for b in blocks if not b.get("page?")]
+        block_results = SearchToolHandler._filter_db_block_results(
+            block_results, api, excluded_page_names
+        )
 
         if include_pages and page_results:
             visible_pages = [
@@ -1219,6 +1263,7 @@ class SearchToolHandler(ToolHandler):
         result: dict, query: str, limit: int,
         include_blocks: bool, include_pages: bool, include_files: bool,
         excluded_page_names: set[str] = frozenset(),
+        api=None,
     ) -> dict:
         """Build structured search results with UUIDs and page identifiers.
 
@@ -1238,8 +1283,12 @@ class SearchToolHandler(ToolHandler):
                     not in excluded_page_names
                 ]
             if include_blocks:
+                visible_blocks = SearchToolHandler._filter_db_block_results(
+                    [b for b in blocks if not b.get("page?")],
+                    api, excluded_page_names,
+                )
                 block_results = []
-                for block in [b for b in blocks if not b.get("page?")][:limit]:
+                for block in visible_blocks[:limit]:
                     block = dict(block)
                     content = block.get("content", "")
                     block["content"] = content.replace("$pfts_2lqh>$", "").replace(
@@ -1306,7 +1355,7 @@ class SearchToolHandler(ToolHandler):
 
             if args.get("format") == "json":
                 json_result = self._build_json_results(
-                    result, query, limit, include_blocks, include_pages, include_files, excluded_page_names
+                    result, query, limit, include_blocks, include_pages, include_files, excluded_page_names, api
                 )
                 return [TextContent(type="text", text=json.dumps(json_result, indent=2))]
 
@@ -1316,7 +1365,7 @@ class SearchToolHandler(ToolHandler):
 
             if _db_mode:
                 content_parts.extend(
-                    self._format_db_mode_results(result, limit, include_blocks, include_pages, include_files, excluded_page_names)
+                    self._format_db_mode_results(result, limit, include_blocks, include_pages, include_files, excluded_page_names, api)
                 )
             else:
                 content_parts.extend(
@@ -1415,15 +1464,28 @@ class QueryToolHandler(ToolHandler):
         return None
 
     def _block_blocked(self, item: dict, api) -> bool:
-        """Fail-closed namespace check for a DSL block result.
+        """Fail-closed tag AND namespace check for a DSL block result.
 
-        Only consulted when namespace rules are configured. A block whose owning
-        page cannot be resolved is treated as blocked.
+        Consulted whenever ANY rule (tag or namespace) is configured. The owning
+        page is resolved once via ``_block_page_name``; the block is dropped if
+        that page is namespace-blocked OR tag-excluded. A block whose owning page
+        cannot be resolved is treated as blocked (fail-closed).
         """
         page_name = self._block_page_name(item, api)
         if page_name is None:
             return True
-        return _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces)
+        if _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces):
+            return True
+        if _exclude_tags:
+            # Tag exclusion needs the page's properties; resolve the owning page
+            # once and inspect its tags. Fail-closed if it cannot be fetched.
+            try:
+                page = api.get_page_content(page_name)
+            except Exception:
+                return True
+            if page and _is_page_excluded(page.get("page", {}), _exclude_tags):
+                return True
+        return False
 
     def _format_item(self, item: dict, index: int) -> str:
         """Format a single result item with type indicator."""
@@ -1478,18 +1540,19 @@ class QueryToolHandler(ToolHandler):
                 filtered_results.append(item)
 
             # Security: filter page objects blocked by tag OR namespace, AND
-            # block objects whose owning page is in a blocked namespace.
-            # Blocks carry content but no tags, so only namespace rules apply to
-            # them; resolution is fail-closed (unresolvable page => dropped).
+            # block objects whose owning page is blocked by tag OR namespace.
+            # A block's owning page is resolvable (_block_page_name), so its TAGS
+            # are checkable too — block filtering must run whenever ANY rule is
+            # active (tag-only profiles included). Resolution is fail-closed
+            # (unresolvable owning page => dropped).
             if _exclude_tags or _include_namespaces or _exclude_namespaces:
-                ns_rules = bool(_include_namespaces or _exclude_namespaces)
                 filtered = []
                 for item in filtered_results:
                     if self._is_page(item):
                         name = item.get("originalName") or item.get("name", "")
                         if _is_page_blocked(item, name):
                             continue
-                    elif self._is_block(item) and ns_rules:
+                    elif self._is_block(item):
                         if self._block_blocked(item, api):
                             continue
                     filtered.append(item)

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1326,6 +1326,37 @@ class QueryToolHandler(ToolHandler):
             return False
         return bool(item.get("content") or item.get("block/content"))
 
+    @staticmethod
+    def _block_page_name(item: dict, api) -> str | None:
+        """Resolve the owning page name for a DSL block result.
+
+        Prefers the inline 'page' reference carried by the query result; falls
+        back to an API lookup by block UUID. Returns None when it cannot be
+        determined (callers treat that as fail-closed when rules are set).
+        """
+        page_ref = item.get("page")
+        if isinstance(page_ref, dict):
+            name = page_ref.get("originalName") or page_ref.get("name")
+            if name:
+                return name
+        elif isinstance(page_ref, str) and page_ref:
+            return page_ref
+        uuid = item.get("uuid")
+        if uuid:
+            return api.get_block_page_name(uuid)
+        return None
+
+    def _block_blocked(self, item: dict, api) -> bool:
+        """Fail-closed namespace check for a DSL block result.
+
+        Only consulted when namespace rules are configured. A block whose owning
+        page cannot be resolved is treated as blocked.
+        """
+        page_name = self._block_page_name(item, api)
+        if page_name is None:
+            return True
+        return _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces)
+
     def _format_item(self, item: dict, index: int) -> str:
         """Format a single result item with type indicator."""
         if not isinstance(item, dict):
@@ -1378,13 +1409,20 @@ class QueryToolHandler(ToolHandler):
                     continue
                 filtered_results.append(item)
 
-            # Security: filter page objects blocked by tag OR namespace
+            # Security: filter page objects blocked by tag OR namespace, AND
+            # block objects whose owning page is in a blocked namespace.
+            # Blocks carry content but no tags, so only namespace rules apply to
+            # them; resolution is fail-closed (unresolvable page => dropped).
             if _exclude_tags or _include_namespaces or _exclude_namespaces:
+                ns_rules = bool(_include_namespaces or _exclude_namespaces)
                 filtered = []
                 for item in filtered_results:
                     if self._is_page(item):
                         name = item.get("originalName") or item.get("name", "")
                         if _is_page_blocked(item, name):
+                            continue
+                    elif self._is_block(item) and ns_rules:
+                        if self._block_blocked(item, api):
                             continue
                     filtered.append(item)
                 filtered_results = filtered

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -185,19 +185,24 @@ def _enforce_page_tag_access(api, page_name: str) -> None:
     Complements the name-based namespace check on write handlers: namespace
     rules can be evaluated from the name alone, but tag exclusion requires the
     page's properties, so this fetches the page. A no-op when no exclude tags
-    are configured. Pages that cannot be fetched are treated as not-excluded
-    (the namespace check has already run, and a missing page is handled by the
-    underlying write call).
+    are configured.
+
+    Two cases are NOT excluded — but only the first is also a quiet pass:
+    - ``get_page_content`` returns None/empty: the page does not exist (or has
+      no properties) and therefore carries no tags. Treated as NOT excluded so
+      ``update_page`` keeps working for brand-new pages.
+    - ``get_page_content`` RAISES: with exclude tags configured we cannot verify
+      the page's tags, so we must NOT silently proceed with the write. The error
+      is allowed to propagate (no try/except) so the calling write handler
+      aborts the mutation via its normal error path (fail-closed). It is not an
+      AccessDenied, so it isn't mislabeled — it just isn't swallowed.
     """
     if not _exclude_tags:
         return
-    try:
-        result = api.get_page_content(page_name)
-    except Exception as e:
-        logger.warning(
-            f"Could not fetch page '{page_name}' for tag-exclusion check: {e}"
-        )
-        return
+    # No try/except by design: when exclude tags are configured, a fetch error
+    # must abort the write rather than fail open. A non-existent page returns
+    # None and falls through as not-excluded.
+    result = api.get_page_content(page_name)
     if result and _is_page_excluded(result.get("page", {}), _exclude_tags):
         raise AccessDenied(
             f"Access denied: page '{page_name}' is restricted "
@@ -1841,6 +1846,9 @@ class RenamePageToolHandler(ToolHandler):
 
         try:
             api = _make_api()
+            # Tag-on-write: guard the SOURCE page (existing). The target name is
+            # a not-yet-existing page, so it has no prior tags to check.
+            _enforce_page_tag_access(api, old_name)
             api.rename_page(old_name, new_name)
 
             return [TextContent(
@@ -1848,6 +1856,8 @@ class RenamePageToolHandler(ToolHandler):
                 text=f"Successfully renamed page '{old_name}' to '{new_name}'\n"
                      f"All references in the graph have been updated."
             )]
+        except AccessDenied:
+            raise
         except ValueError as e:
             return [TextContent(
                 type="text",
@@ -2010,6 +2020,7 @@ class InsertNestedBlockToolHandler(ToolHandler):
         try:
             api = _make_api()
             _enforce_block_namespace_access(api, parent_uuid)
+            _enforce_block_tag_access(api, parent_uuid)
             result = api.insert_block_as_child(
                 parent_block_uuid=parent_uuid,
                 content=content,

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -965,6 +965,7 @@ class GetBlockToolHandler(ToolHandler):
         try:
             api = _make_api()
             _enforce_block_namespace_access(api, block_uuid)
+            _enforce_block_tag_access(api, block_uuid)
             result = api.get_block(block_uuid, include_children=include_children)
 
             if output_format == "json":
@@ -1154,7 +1155,10 @@ class SearchToolHandler(ToolHandler):
         """
         parts: list[str] = []
 
-        if include_blocks and result.get("blocks"):
+        if include_blocks and result.get("blocks") and not excluded_page_names:
+            # Only show blocks when no exclusion is active — markdown-mode blocks
+            # carry block/content but no page identifier, so we cannot verify they
+            # are safe to show (same rule as the page-snippets section below)
             blocks = result["blocks"]
             parts.append(f"## Content Blocks ({len(blocks)} found)")
             for i, block in enumerate(blocks[:limit]):
@@ -1247,7 +1251,10 @@ class SearchToolHandler(ToolHandler):
                 out["files"] = result.get("files", [])
             out["has_more"] = bool(result.get("hasMore?"))
         else:
-            if include_blocks:
+            if include_blocks and not excluded_page_names:
+                # Markdown-mode blocks carry block/content but no page
+                # identifier, so they cannot be exclusion-filtered — only expose
+                # them when no exclusion is active (same rule as snippets)
                 out["blocks"] = result.get("blocks", [])[:limit]
             if include_pages:
                 out["pages"] = [

--- a/src/mcp_logseq/transport/auth.py
+++ b/src/mcp_logseq/transport/auth.py
@@ -20,21 +20,43 @@ class BearerAuthMiddleware:
 
     def __init__(self, app: ASGIApp, token: str) -> None:
         self._app = app
-        self._token = token
+        # Compare as bytes: hmac.compare_digest rejects str with non-ASCII
+        # chars, so a non-ASCII header would crash if compared as str.
+        self._token = token.encode("utf-8")
+        self._prefix = b"Bearer "
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
             await self._app(scope, receive, send)
             return
 
-        headers = dict(scope.get("headers") or [])
-        auth = headers.get(b"authorization", b"").decode()
-        prefix = "Bearer "
-        presented = auth[len(prefix):] if auth.startswith(prefix) else ""
+        # ASGI headers are a list of (name, value) tuples; duplicates are
+        # permitted. Reject anything other than exactly one Authorization
+        # header (zero = missing, >1 = ambiguous and last-wins-spoofable).
+        auth_values = [
+            value
+            for name, value in (scope.get("headers") or [])
+            if name == b"authorization"
+        ]
+        if len(auth_values) != 1:
+            await self._unauthorized(scope, receive, send)
+            return
+
+        # Compare raw bytes (no decode): Bearer tokens are ASCII-only
+        # (RFC 6750 token68), and a strict UTF-8 decode of garbage bytes would
+        # otherwise raise and surface as a 500 instead of a clean 401.
+        auth = auth_values[0]
+        if not auth.startswith(self._prefix):
+            await self._unauthorized(scope, receive, send)
+            return
+        presented = auth[len(self._prefix):]
 
         if not presented or not hmac.compare_digest(presented, self._token):
-            response = JSONResponse({"error": "unauthorized"}, status_code=401)
-            await response(scope, receive, send)
+            await self._unauthorized(scope, receive, send)
             return
 
         await self._app(scope, receive, send)
+
+    async def _unauthorized(self, scope: Scope, receive: Receive, send: Send) -> None:
+        response = JSONResponse({"error": "unauthorized"}, status_code=401)
+        await response(scope, receive, send)

--- a/src/mcp_logseq/transport/auth.py
+++ b/src/mcp_logseq/transport/auth.py
@@ -1,41 +1,40 @@
 """Bearer token authentication middleware for the HTTP transport.
 
-NOTE: This is a MINIMAL placeholder added in Task 1 so ``transport/http.py``
-imports cleanly and the route can enforce a 401 for missing/invalid tokens.
-Task 2 will replace/extend this with the full bearer-auth implementation
-(constant-time comparison, scheme validation, structured error bodies, etc.).
+Pure ASGI middleware (intentionally NOT a ``BaseHTTPMiddleware`` subclass:
+that base class buffers the response body and breaks the streaming/SSE that
+Streamable HTTP relies on). Token comparison is constant-time via
+:func:`hmac.compare_digest`.
+
+Token source: the ``MCP_HTTP_AUTH_TOKEN`` env var (required in http mode) is
+read by the caller (CLI wiring, Task 3) and passed in here as ``token``.
 """
 
-from starlette.requests import Request
+import hmac
+
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 class BearerAuthMiddleware:
-    """Reject requests lacking a valid ``Authorization: Bearer <token>`` header.
-
-    Minimal implementation: compares the presented token against the configured
-    ``token`` and returns 401 on mismatch. Hardened in Task 2.
-    """
+    """Reject requests lacking a valid ``Authorization: Bearer <token>`` header."""
 
     def __init__(self, app: ASGIApp, token: str) -> None:
-        self.app = app
-        self.token = token
+        self._app = app
+        self._token = token
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
-            await self.app(scope, receive, send)
+            await self._app(scope, receive, send)
             return
 
-        request = Request(scope)
-        header = request.headers.get("authorization", "")
-        expected = f"Bearer {self.token}"
+        headers = dict(scope.get("headers") or [])
+        auth = headers.get(b"authorization", b"").decode()
+        prefix = "Bearer "
+        presented = auth[len(prefix):] if auth.startswith(prefix) else ""
 
-        if header != expected:
-            response = JSONResponse(
-                {"error": "unauthorized"}, status_code=401
-            )
+        if not presented or not hmac.compare_digest(presented, self._token):
+            response = JSONResponse({"error": "unauthorized"}, status_code=401)
             await response(scope, receive, send)
             return
 
-        await self.app(scope, receive, send)
+        await self._app(scope, receive, send)

--- a/src/mcp_logseq/transport/auth.py
+++ b/src/mcp_logseq/transport/auth.py
@@ -1,0 +1,41 @@
+"""Bearer token authentication middleware for the HTTP transport.
+
+NOTE: This is a MINIMAL placeholder added in Task 1 so ``transport/http.py``
+imports cleanly and the route can enforce a 401 for missing/invalid tokens.
+Task 2 will replace/extend this with the full bearer-auth implementation
+(constant-time comparison, scheme validation, structured error bodies, etc.).
+"""
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class BearerAuthMiddleware:
+    """Reject requests lacking a valid ``Authorization: Bearer <token>`` header.
+
+    Minimal implementation: compares the presented token against the configured
+    ``token`` and returns 401 on mismatch. Hardened in Task 2.
+    """
+
+    def __init__(self, app: ASGIApp, token: str) -> None:
+        self.app = app
+        self.token = token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
+        header = request.headers.get("authorization", "")
+        expected = f"Bearer {self.token}"
+
+        if header != expected:
+            response = JSONResponse(
+                {"error": "unauthorized"}, status_code=401
+            )
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/src/mcp_logseq/transport/http.py
+++ b/src/mcp_logseq/transport/http.py
@@ -21,13 +21,15 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from ..server import build_app
 
 
-def create_asgi_app(auth_token: str) -> Starlette:
+def create_asgi_app(auth_token: str, read_only: bool = False) -> Starlette:
     """Build a Starlette ASGI app serving the MCP server at ``/mcp``.
 
     Args:
         auth_token: Bearer token required on incoming requests.
+        read_only: When True, the served app exposes only read tools (write
+            tools are not registered).
     """
-    app, _ = build_app()
+    app, _ = build_app(read_only=read_only)
     manager = StreamableHTTPSessionManager(app=app)
 
     async def handle(scope, receive, send):
@@ -46,8 +48,12 @@ def create_asgi_app(auth_token: str) -> Starlette:
     return asgi
 
 
-def run_http(host: str, port: int, auth_token: str) -> None:
+def run_http(
+    host: str, port: int, auth_token: str, read_only: bool = False
+) -> None:
     """Run the HTTP transport with uvicorn (imported lazily)."""
     import uvicorn
 
-    uvicorn.run(create_asgi_app(auth_token), host=host, port=port)
+    uvicorn.run(
+        create_asgi_app(auth_token, read_only=read_only), host=host, port=port
+    )

--- a/src/mcp_logseq/transport/http.py
+++ b/src/mcp_logseq/transport/http.py
@@ -1,0 +1,53 @@
+"""HTTP (Streamable HTTP / SSE) ASGI transport for the LogSeq MCP server.
+
+Wraps the MCP ``Server`` from :mod:`mcp_logseq.server` in a Starlette app and
+serves it over the Streamable HTTP transport.
+
+StreamableHTTPSessionManager (confirmed against installed mcp 1.27.2):
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+    StreamableHTTPSessionManager(app, event_store=None, json_response=False,
+                                 stateless=False, ...)
+    async def handle_request(scope, receive, send) -> None
+    def run() -> AsyncIterator[None]   # async context manager (task group)
+"""
+
+import contextlib
+from collections.abc import AsyncIterator
+
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+from ..server import build_app
+
+
+def create_asgi_app(auth_token: str) -> Starlette:
+    """Build a Starlette ASGI app serving the MCP server at ``/mcp``.
+
+    Args:
+        auth_token: Bearer token required on incoming requests.
+    """
+    app = build_app()
+    manager = StreamableHTTPSessionManager(app=app)
+
+    async def handle(scope, receive, send):
+        await manager.handle_request(scope, receive, send)
+
+    @contextlib.asynccontextmanager
+    async def lifespan(_: Starlette) -> AsyncIterator[None]:
+        async with manager.run():
+            yield
+
+    asgi = Starlette(routes=[Mount("/mcp", app=handle)], lifespan=lifespan)
+
+    from .auth import BearerAuthMiddleware
+
+    asgi.add_middleware(BearerAuthMiddleware, token=auth_token)
+    return asgi
+
+
+def run_http(host: str, port: int, auth_token: str) -> None:
+    """Run the HTTP transport with uvicorn (imported lazily)."""
+    import uvicorn
+
+    uvicorn.run(create_asgi_app(auth_token), host=host, port=port)

--- a/src/mcp_logseq/transport/http.py
+++ b/src/mcp_logseq/transport/http.py
@@ -27,7 +27,7 @@ def create_asgi_app(auth_token: str) -> Starlette:
     Args:
         auth_token: Bearer token required on incoming requests.
     """
-    app = build_app()
+    app, _ = build_app()
     manager = StreamableHTTPSessionManager(app=app)
 
     async def handle(scope, receive, send):

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -193,7 +193,7 @@ class VectorSearchToolHandler(ToolHandler):
                 detail = ", ".join(parts)
                 output_prefix = (
                     f"Note: {detail} since last sync. "
-                    f"Ensure logseq-sync --watch is running, or call sync_vector_db. "
+                    f"Ensure `logseq-sync --watch` is running on the host that owns the DB. "
                     f"Results below may be incomplete.\n\n"
                 )
         except Exception as e:

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -25,6 +25,7 @@ from mcp_logseq.tools import (
     _is_namespace_blocked,
     _include_namespaces,
     _exclude_namespaces,
+    _exclude_tags,
 )
 from mcp_logseq.vector.db import VectorDB
 from mcp_logseq.vector.embedder import create_embedder
@@ -53,6 +54,20 @@ def _filter_results_by_namespace(
     if not include and not exclude:
         return results
     return [r for r in results if not _is_namespace_blocked(r.page, include, exclude)]
+
+
+def _filter_results_by_tags(
+    results: list[SearchResult], exclude_tags: list[str]
+) -> list[SearchResult]:
+    """Drop vector search results whose page carries an excluded tag.
+
+    Mirrors the namespace filter: on a shared DB this prevents tag-blocked
+    pages (e.g. #keys) from leaking to a profile that excludes that tag.
+    Tag data is already on each result, so no API call is needed.
+    """
+    if not exclude_tags:
+        return results
+    return [r for r in results if not any(t in exclude_tags for t in (r.tags or []))]
 
 
 def _format_search_results(results) -> str:
@@ -229,6 +244,7 @@ class VectorSearchToolHandler(ToolHandler):
         results = _filter_results_by_namespace(
             results, _include_namespaces, _exclude_namespaces
         )
+        results = _filter_results_by_tags(results, _exclude_tags)
         output = output_prefix + _format_search_results(results)
         return [TextContent(type="text", text=output)]
 

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import logging
 import os
-import subprocess
-import sys
 import time
 from pathlib import Path
 
@@ -258,15 +256,16 @@ class SyncVectorDBToolHandler(ToolHandler):
         return Tool(
             name=self.name,
             description=(
-                "Run incremental sync of the vector database against current Logseq graph files. "
-                "Only changed files are re-embedded. Use rebuild=true to drop and re-index everything."
+                "Vector DB sync is NOT available via MCP. The vector database has a single "
+                "writer — the logseq-sync CLI, run externally on the host that owns the DB. "
+                "Calling this tool just returns instructions; it does not start a sync."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "rebuild": {
                         "type": "boolean",
-                        "description": "If true, drop the entire DB and re-index from scratch",
+                        "description": "Ignored. Sync runs externally via logseq-sync --rebuild.",
                         "default": False,
                     },
                 },
@@ -274,28 +273,13 @@ class SyncVectorDBToolHandler(ToolHandler):
         )
 
     def run_tool(self, args: dict) -> list[TextContent]:
-        rebuild = bool(args.get("rebuild", False))
-
-        cmd = [sys.executable, "-m", "mcp_logseq.bin.logseq_sync"]
-        cmd.append("--rebuild" if rebuild else "--once")
-
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-        except subprocess.TimeoutExpired:
-            return [TextContent(type="text", text="Sync timed out after 10 minutes.")]
-        except Exception as e:
-            return [TextContent(type="text", text=f"Sync failed: {e}")]
-
-        if result.returncode != 0:
-            error = result.stderr.strip() or result.stdout.strip() or "Unknown error"
-            return [TextContent(type="text", text=f"Sync failed:\n{error}")]
-
-        return [TextContent(type="text", text=result.stdout.strip())]
+        message = (
+            "Vector DB sync is not available via MCP. Run it on the host that owns the DB:\n"
+            "  logseq-sync --once      # incremental sync\n"
+            "  logseq-sync --watch     # continuous file watcher\n"
+            "  logseq-sync --rebuild   # drop and re-index everything"
+        )
+        return [TextContent(type="text", text=message)]
 
 
 class VectorDBStatusToolHandler(ToolHandler):

--- a/tests/integration/test_http_serving.py
+++ b/tests/integration/test_http_serving.py
@@ -1,0 +1,279 @@
+"""End-to-end HTTP serving + profile isolation (Task 7).
+
+Acceptance coverage for the secure HTTP serving feature. A single profile is
+used throughout: a ``Journal/*``-only allow-list (``Work/*`` denied) behind a
+known bearer token.
+
+Strategy note
+-------------
+Two layers are exercised:
+
+* **AUTH** runs through the REAL stack: a context-manager ``TestClient`` over
+  the actual Starlette app produced by ``create_asgi_app`` — i.e. through the
+  genuine ``BearerAuthMiddleware`` and the mounted ``/mcp`` route. No token /
+  wrong token must 401; the right token must pass the middleware (not 401).
+
+* **ISOLATION** and **READ-ONLY** use *strategy B* (per the task brief). A full
+  in-process MCP Streamable-HTTP handshake (initialize/initialized + SSE) is
+  brittle to drive in-process and would mostly re-test the MCP SDK's wire
+  protocol rather than this project's security contract. Instead we drive the
+  EXACT handler registry the served app exposes — ``build_app(read_only=...)``
+  returns ``(server, handlers)`` where ``handlers`` is the same dict the app's
+  ``call_tool`` closure dispatches to — with the profile's ACL globals active.
+  This proves denied-namespace content never surfaces and that the read-only
+  app's tool set omits genuine write tools, end-to-end through the served app
+  object, without re-testing the SDK.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from mcp_logseq.transport.http import create_asgi_app
+from mcp_logseq.server import build_app, _WRITE_TOOL_NAMES
+from mcp_logseq.tools import AccessDenied
+
+
+TOKEN = "journal-profile-token"
+
+
+def _journal_only_profile():
+    """Activate the Journal-only ACL profile on the served handlers' globals.
+
+    ``include=['Journal']`` is a strict allow-list: only ``Journal`` and its
+    children are reachable; ``Work/*`` (and every other namespace) is denied.
+    """
+    return patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=["Journal"],
+        _exclude_namespaces=[],
+        _exclude_tags=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 1 + Step 2: build the served app and assert auth through the real stack.
+# ---------------------------------------------------------------------------
+
+
+def test_no_token_is_rejected_through_real_middleware(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    with TestClient(create_asgi_app(auth_token=TOKEN)) as client:
+        r = client.post(
+            "/mcp/", json={"jsonrpc": "2.0", "id": 1, "method": "ping"}
+        )
+    assert r.status_code == 401
+
+
+def test_wrong_token_is_rejected_through_real_middleware(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    with TestClient(create_asgi_app(auth_token=TOKEN)) as client:
+        r = client.post(
+            "/mcp/",
+            headers={"Authorization": "Bearer wrong-token"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        )
+    assert r.status_code == 401
+
+
+def test_correct_token_passes_middleware(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    # Context-manager TestClient runs the lifespan so the MCP session task
+    # group is initialized; /mcp/ avoids the 307 redirect.
+    with TestClient(create_asgi_app(auth_token=TOKEN)) as client:
+        r = client.post(
+            "/mcp/",
+            headers={"Authorization": f"Bearer {TOKEN}"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        )
+    # The correct token cleared the middleware; whatever the MCP layer answers,
+    # it must NOT be the auth rejection and must not be a post-auth crash.
+    assert r.status_code != 401
+    assert r.status_code < 500
+
+
+# ---------------------------------------------------------------------------
+# Step 3: isolation — denied (Work/*) content never surfaces; Journal/* does.
+# Driven through the SAME handler registry the served app dispatches to.
+# ---------------------------------------------------------------------------
+
+
+def _served_handlers(read_only: bool = False) -> dict:
+    """The exact handler registry the served HTTP app dispatches tool calls to."""
+    _, handlers = build_app(read_only=read_only)
+    return handlers
+
+
+def test_get_page_content_denies_work_page(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    handlers = _served_handlers()
+    with _journal_only_profile():
+        with pytest.raises(AccessDenied):
+            handlers["get_page_content"].run_tool({"page_name": "Work/secret-roadmap"})
+
+
+def test_query_for_work_page_returns_nothing(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"originalName": "Work/secret-roadmap"},
+        {"originalName": "Work/salaries"},
+    ]
+    handlers = _served_handlers()
+    with _journal_only_profile(), patch(
+        "mcp_logseq.tools._make_api", return_value=fake
+    ):
+        out = handlers["query"].run_tool({"query": "(page-property x)"})[0].text
+    assert "Work/" not in out
+    assert "secret-roadmap" not in out
+    assert "salaries" not in out
+
+
+def test_search_excludes_work_pages_and_keeps_journal(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    fake = Mock()
+    fake.list_pages.return_value = [
+        {"originalName": "Work/secret-roadmap", "properties": {}},
+        {"originalName": "Journal/2026-06-15", "properties": {}},
+    ]
+    handlers = _served_handlers()
+    # The served search handler resolves blocked page names via the SAME helper
+    # the live tool uses; assert Work/* is on the excluded list and Journal is not.
+    handler = handlers["search"]
+    with _journal_only_profile(), patch(
+        "mcp_logseq.tools._make_api", return_value=fake
+    ):
+        # Signature: (api, exclude_tags, exclude_namespaces, include_namespaces).
+        # Returns lowercased names of blocked pages.
+        excluded = handler._build_excluded_page_names(
+            fake, [], [], ["Journal"]
+        )
+    assert "work/secret-roadmap" in excluded
+    assert "journal/2026-06-15" not in excluded
+
+
+def test_journal_page_is_reachable(monkeypatch):
+    """A Journal/* page passes the pre-flight guard and returns its content."""
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    fake = Mock()
+    fake.get_page_content.return_value = {
+        "page": {"originalName": "Journal/2026-06-15", "properties": {}},
+        "blocks": [{"content": "Today I shipped the HTTP transport"}],
+    }
+    handlers = _served_handlers()
+    with _journal_only_profile(), patch(
+        "mcp_logseq.tools._make_api", return_value=fake
+    ):
+        out = handlers["get_page_content"].run_tool(
+            {"page_name": "Journal/2026-06-15", "format": "text"}
+        )[0].text
+    assert "Today I shipped the HTTP transport" in out
+
+
+def test_vector_search_registered_and_isolated(monkeypatch, tmp_path):
+    """When vector is configured, the served app registers vector_search, and
+    the namespace filter that tool relies on drops Work/* while keeping
+    Journal/*. If the vector extra is unavailable, skip cleanly."""
+    pytest.importorskip("mcp_logseq.vector.index")
+    import json
+
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "logseq_graph_path": str(tmp_path),
+                "vector": {
+                    "enabled": True,
+                    "db_path": str(tmp_path / "db"),
+                    "embedder": {"provider": "ollama", "model": "nomic-embed-text"},
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+
+    handlers = _served_handlers()
+    assert "vector_search" in handlers, "vector_search must be exposed by served app"
+
+    # The served vector tool filters its results through this helper. Under the
+    # Journal-only profile, a Work/* hit physically present in a shared index
+    # must be dropped; Journal/* survives.
+    from mcp_logseq.vector.index import _filter_results_by_namespace
+
+    class R:
+        def __init__(self, page):
+            self.page = page
+
+    results = [R("Work/secret-roadmap"), R("Journal/2026-06-15")]
+    kept = _filter_results_by_namespace(results, include=["Journal"], exclude=[])
+    pages = [r.page for r in kept]
+    assert pages == ["Journal/2026-06-15"]
+
+
+# ---------------------------------------------------------------------------
+# Step 4: writes — denied namespace raises; read-only app drops write tools.
+# ---------------------------------------------------------------------------
+
+
+def test_write_to_work_page_is_denied(monkeypatch):
+    """On a writable served app, a write targeting Work/* raises AccessDenied."""
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    handlers = _served_handlers(read_only=False)
+    assert "create_page" in handlers  # writable instance
+    with _journal_only_profile():
+        with pytest.raises(AccessDenied):
+            handlers["create_page"].run_tool(
+                {"title": "Work/new-plan", "content": "secret"}
+            )
+        with pytest.raises(AccessDenied):
+            handlers["update_page"].run_tool(
+                {"page_name": "Work/secret-roadmap", "content": "x"}
+            )
+
+
+def test_read_only_served_app_omits_write_tools(monkeypatch):
+    """The read-only served app exposes NO genuine write tool; read tools stay."""
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    handlers = _served_handlers(read_only=True)
+    for name in _WRITE_TOOL_NAMES:
+        assert name not in handlers, f"{name} must be absent under read_only"
+    for name in [
+        "list_pages",
+        "get_page_content",
+        "search",
+        "query",
+        "get_pages_from_namespace",
+        "get_page_backlinks",
+    ]:
+        assert name in handlers, f"read tool {name} must remain under read_only"
+
+
+def test_read_only_keeps_sync_vector_when_configured(monkeypatch, tmp_path):
+    """sync_vector_db is not a genuine write tool; it survives read-only when
+    vector is configured for the served app."""
+    pytest.importorskip("mcp_logseq.vector.index")
+    import json
+
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "logseq_graph_path": str(tmp_path),
+                "vector": {
+                    "enabled": True,
+                    "db_path": str(tmp_path / "db"),
+                    "embedder": {"provider": "ollama", "model": "nomic-embed-text"},
+                },
+            }
+        )
+    )
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+
+    handlers = _served_handlers(read_only=True)
+    for name in ["sync_vector_db", "vector_search", "vector_db_status"]:
+        assert name in handlers, f"{name} must remain under read_only"
+    for name in _WRITE_TOOL_NAMES:
+        assert name not in handlers

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,50 @@
+"""Unit tests for the CLI argument parsing and transport dispatch."""
+
+import pytest
+
+import mcp_logseq
+from mcp_logseq import parse_args
+
+
+def test_parse_args_http_explicit():
+    ns = parse_args(["--transport", "http", "--host", "127.0.0.1", "--port", "12320"])
+    assert ns.transport == "http"
+    assert ns.host == "127.0.0.1"
+    assert ns.port == 12320
+
+
+def test_parse_args_defaults():
+    ns = parse_args([])
+    assert ns.transport == "stdio"
+    assert ns.host == "127.0.0.1"
+    assert ns.port == 12320
+
+
+def test_main_http_without_token_raises(monkeypatch):
+    monkeypatch.delenv("MCP_HTTP_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr(mcp_logseq, "parse_args", lambda argv=None: parse_args(["--transport", "http"]))
+
+    # Guard: even if it got past the token check, don't actually bind.
+    import mcp_logseq.transport.http as http_mod
+    monkeypatch.setattr(http_mod, "run_http", lambda *a, **k: None)
+
+    with pytest.raises(SystemExit):
+        mcp_logseq.main()
+
+
+def test_main_http_with_token_calls_run_http(monkeypatch):
+    monkeypatch.setenv("MCP_HTTP_AUTH_TOKEN", "secret-token")
+    monkeypatch.setattr(
+        mcp_logseq,
+        "parse_args",
+        lambda argv=None: parse_args(["--transport", "http", "--host", "127.0.0.1", "--port", "12320"]),
+    )
+
+    calls = []
+
+    import mcp_logseq.transport.http as http_mod
+    monkeypatch.setattr(http_mod, "run_http", lambda *a, **k: calls.append((a, k)))
+
+    mcp_logseq.main()
+
+    assert calls == [(("127.0.0.1", 12320, "secret-token"), {})]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -59,4 +59,24 @@ def test_main_http_with_token_calls_run_http(monkeypatch):
 
     mcp_logseq.main()
 
-    assert calls == [(("127.0.0.1", 12320, "secret-token"), {})]
+    assert calls == [(("127.0.0.1", 12320, "secret-token"), {"read_only": False})]
+
+
+def test_main_http_read_only_threaded(monkeypatch):
+    monkeypatch.setenv("MCP_HTTP_AUTH_TOKEN", "secret-token")
+    monkeypatch.setattr(
+        mcp_logseq,
+        "parse_args",
+        lambda argv=None: parse_args(
+            ["--transport", "http", "--port", "12320", "--read-only"]
+        ),
+    )
+
+    calls = []
+
+    import mcp_logseq.transport.http as http_mod
+    monkeypatch.setattr(http_mod, "run_http", lambda *a, **k: calls.append((a, k)))
+
+    mcp_logseq.main()
+
+    assert calls == [(("127.0.0.1", 12320, "secret-token"), {"read_only": True})]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,16 +20,28 @@ def test_parse_args_defaults():
     assert ns.port == 12320
 
 
+def test_parse_args_invalid_transport_exits():
+    with pytest.raises(SystemExit) as excinfo:
+        parse_args(["--transport", "bogus"])
+    # argparse exits with code 2 on an invalid choice.
+    assert excinfo.value.code == 2
+
+
 def test_main_http_without_token_raises(monkeypatch):
     monkeypatch.delenv("MCP_HTTP_AUTH_TOKEN", raising=False)
     monkeypatch.setattr(mcp_logseq, "parse_args", lambda argv=None: parse_args(["--transport", "http"]))
 
-    # Guard: even if it got past the token check, don't actually bind.
+    # Record any call: SystemExit must fire BEFORE run_http is reached, so the
+    # recorder must stay empty. If the token guard is ever removed, this test
+    # fails loudly instead of silently passing.
+    calls = []
     import mcp_logseq.transport.http as http_mod
-    monkeypatch.setattr(http_mod, "run_http", lambda *a, **k: None)
+    monkeypatch.setattr(http_mod, "run_http", lambda *a, **k: calls.append((a, k)))
 
     with pytest.raises(SystemExit):
         mcp_logseq.main()
+
+    assert calls == [], "run_http must not be called when the token is missing"
 
 
 def test_main_http_with_token_calls_run_http(monkeypatch):

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -1,6 +1,34 @@
 import pytest
 from starlette.testclient import TestClient
+from mcp_logseq.transport.auth import BearerAuthMiddleware
 from mcp_logseq.transport.http import create_asgi_app
+
+
+async def _invoke_auth(headers):
+    """Drive BearerAuthMiddleware.__call__ with a hand-built HTTP scope.
+
+    Returns the status code the middleware (or the wrapped app) emits. The
+    wrapped app, if reached, returns 200; auth rejections return 401.
+    """
+
+    async def downstream(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = BearerAuthMiddleware(downstream, token="secret")
+    scope = {"type": "http", "headers": headers, "method": "POST", "path": "/mcp"}
+
+    status = {}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            status["code"] = message["status"]
+
+    await middleware(scope, receive, send)
+    return status["code"]
 
 
 def test_asgi_app_mounts_mcp_endpoint(monkeypatch):
@@ -40,5 +68,33 @@ def test_correct_token_passes_auth(monkeypatch):
             headers={"Authorization": "Bearer secret"},
             json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
         )
-    # Auth let it through; MCP session semantics decide the rest (not 401).
-    assert r.status_code != 401
+    # Auth let it through and the MCP handler responded without crashing.
+    # < 500 catches a post-auth 500; it is also not a 401 rejection.
+    assert r.status_code < 500
+
+
+@pytest.mark.asyncio
+async def test_duplicate_auth_headers_is_401():
+    # One valid + one invalid Authorization header must be rejected (ambiguous),
+    # not accepted by last-wins dict collapsing.
+    status = await _invoke_auth(
+        [
+            (b"authorization", b"Bearer secret"),
+            (b"authorization", b"Bearer nope"),
+        ]
+    )
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_non_ascii_auth_header_is_401():
+    # Non-ASCII bytes must yield a clean 401, never a 500 from a decode crash.
+    status = await _invoke_auth([(b"authorization", b"Bearer \xff\xfe")])
+    assert status == 401
+
+
+@pytest.mark.asyncio
+async def test_single_valid_auth_header_passes():
+    # Sanity check that the hand-built scope path accepts a correct token.
+    status = await _invoke_auth([(b"authorization", b"Bearer secret")])
+    assert status == 200

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -11,3 +11,34 @@ def test_asgi_app_mounts_mcp_endpoint(monkeypatch):
     # No/bad bearer → 401 (auth covered in Task 2; here assert the route exists)
     resp = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
     assert resp.status_code in (401, 400)  # route exists, not 404
+
+
+def test_missing_token_is_401(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    client = TestClient(create_asgi_app(auth_token="secret"))
+    r = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert r.status_code == 401
+
+
+def test_wrong_token_is_401(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    client = TestClient(create_asgi_app(auth_token="secret"))
+    r = client.post(
+        "/mcp",
+        headers={"Authorization": "Bearer nope"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+    assert r.status_code == 401
+
+
+def test_correct_token_passes_auth(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    # Context-manager TestClient runs the app lifespan (MCP session task group).
+    with TestClient(create_asgi_app(auth_token="secret")) as client:
+        r = client.post(
+            "/mcp/",
+            headers={"Authorization": "Bearer secret"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        )
+    # Auth let it through; MCP session semantics decide the rest (not 401).
+    assert r.status_code != 401

--- a/tests/unit/test_http_transport.py
+++ b/tests/unit/test_http_transport.py
@@ -1,0 +1,13 @@
+import pytest
+from starlette.testclient import TestClient
+from mcp_logseq.transport.http import create_asgi_app
+
+
+def test_asgi_app_mounts_mcp_endpoint(monkeypatch):
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "x")
+    monkeypatch.setenv("MCP_HTTP_AUTH_TOKEN", "secret")
+    app = create_asgi_app(auth_token="secret")
+    client = TestClient(app)
+    # No/bad bearer → 401 (auth covered in Task 2; here assert the route exists)
+    resp = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "ping"})
+    assert resp.status_code in (401, 400)  # route exists, not 404

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -681,6 +681,182 @@ def test_query_blocks_pass_when_no_rules():
 
 
 # =============================================================================
+# LEAK 1: DB-mode search must filter block results whose owning page is excluded
+# (both namespace and tag axes), in BOTH text and JSON output paths.
+# DB-mode blocks carry a 'page' field = owning page UUID, so they are resolvable.
+# =============================================================================
+
+
+def test_db_search_filters_block_from_excluded_namespace_text():
+    """DB-mode text output must drop a block whose owning page is namespace-excluded."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "secret salary AKIA-leak", "uuid": "blk-1", "page": "uuid-fin"},
+            {"content": "public roadmap data", "uuid": "blk-2", "page": "uuid-work"},
+        ],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "finance/q3", "properties": {}},
+        {"originalName": "work/x", "properties": {}},
+    ]
+    fake.resolve_page_uuids.return_value = {
+        "uuid-fin": "finance/q3",
+        "uuid-work": "work/x",
+    }
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "data"})[0].text
+        assert "AKIA-leak" not in out
+        assert "blk-1" not in out
+        assert "public roadmap data" in out
+
+
+def test_db_search_filters_block_from_excluded_namespace_json():
+    """DB-mode JSON output must drop a block whose owning page is namespace-excluded."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "secret salary AKIA-leak", "uuid": "blk-1", "page": "uuid-fin"},
+            {"content": "public roadmap data", "uuid": "blk-2", "page": "uuid-work"},
+        ],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "finance/q3", "properties": {}},
+        {"originalName": "work/x", "properties": {}},
+    ]
+    fake.resolve_page_uuids.return_value = {
+        "uuid-fin": "finance/q3",
+        "uuid-work": "work/x",
+    }
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool(
+            {"query": "data", "format": "json"}
+        )[0].text
+        assert "AKIA-leak" not in out
+        assert "blk-1" not in out
+        parsed = json.loads(out)
+        uuids = [b.get("uuid") for b in parsed.get("blocks", [])]
+        assert "blk-1" not in uuids
+        assert "blk-2" in uuids
+
+
+def test_db_search_filters_block_from_tag_excluded_page_text():
+    """DB-mode text output must drop a block whose owning page is TAG-excluded."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "secret key AKIA-leak", "uuid": "blk-1", "page": "uuid-vault"},
+            {"content": "ordinary note", "uuid": "blk-2", "page": "uuid-notes"},
+        ],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "vault", "properties": {"tags": ["keys"]}},
+        {"originalName": "notes", "properties": {}},
+    ]
+    fake.resolve_page_uuids.return_value = {
+        "uuid-vault": "vault",
+        "uuid-notes": "notes",
+    }
+    with patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=[],
+        _exclude_namespaces=[],
+        _exclude_tags=["keys"],
+    ), patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "note"})[0].text
+        assert "AKIA-leak" not in out
+        assert "blk-1" not in out
+        assert "ordinary note" in out
+
+
+def test_db_search_block_fail_closed_when_unresolvable():
+    """Fail-closed: a DB-mode block whose owning page cannot be resolved is dropped
+    while an exclusion rule is active."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "unverifiable AKIA-leak", "uuid": "blk-1", "page": "uuid-???"},
+        ],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "finance/q3", "properties": {}},
+    ]
+    fake.resolve_page_uuids.return_value = {}  # cannot resolve
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "x"})[0].text
+        assert "AKIA-leak" not in out
+
+
+def test_db_search_blocks_pass_when_no_rules():
+    """Control: with no exclusion active, DB-mode blocks surface and no UUID
+    resolution call is made."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "ordinary visible block", "uuid": "blk-1", "page": "uuid-1"},
+        ],
+    }
+    fake.list_pages.return_value = []
+    with _ns(), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "block"})[0].text
+        assert "ordinary visible block" in out
+        fake.resolve_page_uuids.assert_not_called()
+
+
+# =============================================================================
+# LEAK 2: tag-only DSL query profile must filter block results whose owning
+# page is TAG-excluded (no namespace rules set).
+# =============================================================================
+
+
+def test_query_filters_block_from_tag_excluded_page():
+    """With ONLY exclude_tags set (no namespace rules), a query block whose owning
+    page carries an excluded tag must be dropped."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "secret key AKIA-leak", "page": {"originalName": "vault"}},
+        {"content": "public note", "page": {"originalName": "notes"}},
+    ]
+
+    def _content(page_name):
+        if page_name == "vault":
+            return {"page": {"properties": {"tags": ["keys"]}}}
+        return {"page": {"properties": {}}}
+
+    fake.get_page_content.side_effect = _content
+    with patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=[],
+        _exclude_namespaces=[],
+        _exclude_tags=["keys"],
+    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(page-tags)"})[0].text
+        assert "AKIA-leak" not in out
+        assert "public note" in out
+
+
+def test_query_blocks_pass_when_no_rules_tag_axis():
+    """Control: with no rules at all, blocks pass through (no tag fetch)."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "anything", "page": {"originalName": "vault"}},
+    ]
+    with _ns(), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
+        assert "anything" in out
+        fake.get_page_content.assert_not_called()
+
+
+# =============================================================================
 # Task 4b: vector_search must apply _exclude_tags, not just namespace rules.
 # On a shared DB, a #keys-tagged chunk physically present in the index must not
 # surface for a profile that excludes the 'keys' tag.

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -309,6 +309,32 @@ def test_set_block_properties_denies():
 
 
 # =============================================================================
+# Task 4: Content-returning tool ACL audit
+#
+# Every registered tool that can return page/block CONTENT must enforce the
+# namespace/tag guard. The HTTP transport exposes the full tool set, so a guard
+# gap = a data-exfiltration path. Status determined by reading each run_tool:
+#
+#   Tool                            Guard status
+#   ------------------------------  ---------------------------------------------
+#   get_page_content                GUARDED  (pre-flight + _is_page_blocked)
+#   list_pages                      GUARDED  (_is_page_blocked filter)
+#   search                          GUARDED  (_build_excluded_page_names filter)
+#   query (DSL)                     FIXED    (was: pages-only; now blocks too)
+#   find_pages_by_property          GUARDED  (_is_page_blocked filter)
+#   get_page_backlinks              GUARDED  (pre-flight + per-referrer filter)
+#   get_pages_from_namespace        GUARDED  (pre-flight + filter)
+#   get_pages_tree_from_namespace   GUARDED  (pre-flight + prune)
+#   get_block                       GUARDED  (_enforce_block_namespace_access)
+#   vector_search                   FIXED    (was: namespace-only; now tags too)
+#
+# Non-content/write tools (create/update/delete/rename/insert/set_block_props)
+# enforce the guard too, but are covered above (Task 1-3 tests) — they cannot
+# leak existing content.
+# =============================================================================
+
+
+# =============================================================================
 # Task 7: Silent filtering in list/search/query/find_pages_by_property
 # =============================================================================
 
@@ -466,3 +492,140 @@ def test_get_pages_tree_from_namespace_prunes_excluded_subnamespace():
         out = GetPagesTreeFromNamespaceToolHandler().run_tool({"namespace": "work"})[0].text
         assert "work/projects" in out
         assert "work/secret" not in out  # whole subtree pruned (also covers .../keys)
+
+
+# =============================================================================
+# Task 4: DSL query must filter BLOCK results from denied namespaces, not just
+# page objects. A block-returning query (e.g. (page-tags)) could otherwise
+# surface block content owned by a blocked page.
+# =============================================================================
+
+
+def test_query_filters_blocks_from_blocked_namespace_via_inline_page():
+    """A block carrying an inline page ref to a blocked namespace is dropped."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "secret salary data", "page": {"originalName": "finance/q3"}},
+        {"content": "public roadmap", "page": {"originalName": "work/x"}},
+    ]
+    with _ns(exclude=["finance"]), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(page-tags)"})[0].text
+        assert "public roadmap" in out
+        assert "secret salary data" not in out
+        assert "finance/" not in out
+
+
+def test_query_filters_blocks_via_api_page_resolution():
+    """A block lacking an inline page ref is resolved via the API and filtered."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "secret data", "uuid": "blk-1"},
+    ]
+    fake.get_block_page_name.return_value = "finance/q3"
+    with _ns(exclude=["finance"]), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
+        assert "secret data" not in out
+
+
+def test_query_block_denied_when_page_unresolvable_and_rules_set():
+    """Fail-closed: a block whose owning page cannot be resolved is dropped."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "unverifiable block", "uuid": "blk-x"},
+    ]
+    fake.get_block_page_name.return_value = None
+    with _ns(include=["work"]), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
+        assert "unverifiable block" not in out
+
+
+def test_query_block_json_format_also_filtered():
+    """JSON output path must apply the same block filtering as text."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "secret", "page": {"originalName": "finance/q3"}},
+        {"content": "ok", "page": {"originalName": "work/x"}},
+    ]
+    with _ns(exclude=["finance"]), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool(
+            {"query": "(page-tags)", "format": "json"}
+        )[0].text
+        assert "ok" in out
+        assert "secret" not in out
+
+
+def test_query_blocks_pass_when_no_rules():
+    """No ACL rules => blocks pass through untouched, no API resolution calls."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "anything", "uuid": "blk-1"},
+    ]
+    with _ns(), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
+        assert "anything" in out
+        fake.get_block_page_name.assert_not_called()
+
+
+# =============================================================================
+# Task 4b: vector_search must apply _exclude_tags, not just namespace rules.
+# On a shared DB, a #keys-tagged chunk physically present in the index must not
+# surface for a profile that excludes the 'keys' tag.
+# =============================================================================
+
+
+def test_vector_results_filtered_by_tags():
+    pytest.importorskip("mcp_logseq.vector.index")
+    from mcp_logseq.vector.index import _filter_results_by_tags
+
+    class R:
+        def __init__(self, tags):
+            self.tags = tags
+
+    results = [R(["notes"]), R(["keys"]), R(["keys", "notes"]), R([])]
+    kept = _filter_results_by_tags(results, exclude_tags=["keys"])
+    assert [r.tags for r in kept] == [["notes"], []]
+
+
+def test_vector_search_drops_tag_excluded_chunk(monkeypatch):
+    """A #keys chunk in the shared DB must not surface when 'keys' is excluded."""
+    pytest.importorskip("mcp_logseq.vector.index")
+    import mcp_logseq.vector.index as vindex
+    from mcp_logseq.vector.index import VectorSearchToolHandler
+    from mcp_logseq.vector.types import SearchResult
+
+    config = Mock()
+    config.db_path = "/tmp/test-vector-db"
+    config.graph_path = "/tmp/test-graph"
+    config.embedder = "ollama/x"
+
+    secret = SearchResult(
+        page="ApiKeys", text="AKIA-secret-token", raw="", score=0.1,
+        tags=["keys"], date=None, properties={}, chunk_index=0,
+    )
+    ok = SearchResult(
+        page="Roadmap", text="public roadmap", raw="", score=0.2,
+        tags=["notes"], date=None, properties={}, chunk_index=0,
+    )
+
+    meta = Mock()
+    meta.embedder_key = "ollama/x"
+    meta.dimensions = 3
+
+    with (
+        patch.object(vindex, "_exclude_tags", ["keys"]),
+        patch.object(vindex, "_include_namespaces", []),
+        patch.object(vindex, "_exclude_namespaces", []),
+        patch("mcp_logseq.vector.index.StateManager") as mock_sm,
+        patch("mcp_logseq.vector.index.check_staleness") as mock_stale,
+        patch("mcp_logseq.vector.index.create_embedder") as mock_emb,
+        patch("mcp_logseq.vector.index.VectorDB") as mock_db,
+    ):
+        mock_sm.return_value.load.return_value = ({}, meta)
+        mock_stale.return_value = Mock(stale=False)
+        mock_emb.return_value.embed.return_value = [[0.1, 0.1, 0.1]]
+        mock_db.open_readonly.return_value.search.return_value = [secret, ok]
+
+        out = VectorSearchToolHandler(config).run_tool({"query": "keys"})[0].text
+        assert "public roadmap" in out
+        assert "AKIA-secret-token" not in out
+        assert "ApiKeys" not in out

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -693,16 +693,9 @@ def test_regression_rename_page_denies_when_new_private():
 # Task 5 Step 2a: --read-only unregisters genuine write tools only.
 # =============================================================================
 
-_GENUINE_WRITE_TOOLS = {
-    "create_page",
-    "update_page",
-    "delete_page",
-    "rename_page",
-    "update_block",
-    "delete_block",
-    "insert_nested_block",
-    "set_block_properties",
-}
+# Single source of truth — import the server's set rather than duplicating it,
+# so the test and the implementation can't drift.
+from mcp_logseq.server import _WRITE_TOOL_NAMES as _GENUINE_WRITE_TOOLS
 
 
 def test_read_only_unregisters_all_write_tools():
@@ -831,6 +824,40 @@ def test_create_page_exempt_from_tag_on_write():
         # Should not raise on tag grounds (namespace allows it).
         CreatePageToolHandler().run_tool({"title": "work/fresh", "content": "c"})
         fake.get_page_content.assert_not_called()
+
+
+def test_insert_nested_block_denies_tag_excluded_owning_page():
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            InsertNestedBlockToolHandler().run_tool(
+                {"parent_block_uuid": "u1", "content": "c"}
+            )
+
+
+def test_rename_page_denies_tag_excluded_source_page():
+    """Renaming a tag-excluded existing SOURCE page is denied (target is new)."""
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            RenamePageToolHandler().run_tool(
+                {"old_name": "work/secrets", "new_name": "work/renamed"}
+            )
+        # rename_page must guard only the source — never fetch the (new) target.
+
+
+def test_tag_on_write_fails_closed_when_page_fetch_raises():
+    """With exclude tags configured, a page-fetch error must abort the write
+    rather than silently proceeding (no fail-open). The error propagates and the
+    write API is never called."""
+    fake = Mock()
+    fake.get_page_content.side_effect = RuntimeError("API down")
+    with _tags_excluded(), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = UpdatePageToolHandler().run_tool(
+            {"page_name": "work/secrets", "content": "c"}
+        )
+        # The write did NOT succeed: update_page_with_blocks never ran, and the
+        # handler reported failure rather than success.
+        fake.update_page_with_blocks.assert_not_called()
+        assert "Successfully updated" not in out[0].text
 
 
 def test_vector_search_drops_tag_excluded_chunk(monkeypatch):

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -609,6 +609,230 @@ def test_vector_results_filtered_by_tags():
     assert [r.tags for r in kept] == [["notes"], []]
 
 
+# =============================================================================
+# Task 5 Step 1: Regression guard for existing PR #65 write gating.
+# These pin current behavior so the --read-only refactor cannot regress it.
+# Every genuine write tool targeting an excluded namespace must raise.
+# =============================================================================
+
+
+def _priv():
+    """Patch config so the 'Private' namespace is excluded."""
+    return patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=[],
+        _exclude_namespaces=["Private"],
+        _exclude_tags=[],
+    )
+
+
+def test_regression_create_page_denies_private():
+    with _priv():
+        with pytest.raises(AccessDenied):
+            CreatePageToolHandler().run_tool({"title": "Private/x", "content": "c"})
+
+
+def test_regression_update_page_denies_private():
+    with _priv():
+        with pytest.raises(AccessDenied):
+            UpdatePageToolHandler().run_tool({"page_name": "Private/x", "content": "c"})
+
+
+def test_regression_delete_page_denies_private():
+    with _priv():
+        with pytest.raises(AccessDenied):
+            DeletePageToolHandler().run_tool({"page_name": "Private/x"})
+
+
+def test_regression_update_block_denies_private():
+    with _priv(), _api_with_block_page("Private/x"):
+        with pytest.raises(AccessDenied):
+            UpdateBlockToolHandler().run_tool({"block_uuid": "u1", "content": "c"})
+
+
+def test_regression_delete_block_denies_private():
+    with _priv(), _api_with_block_page("Private/x"):
+        with pytest.raises(AccessDenied):
+            DeleteBlockToolHandler().run_tool({"block_uuid": "u1"})
+
+
+def test_regression_insert_nested_block_denies_private():
+    with _priv(), _api_with_block_page("Private/x"):
+        with pytest.raises(AccessDenied):
+            InsertNestedBlockToolHandler().run_tool(
+                {"parent_block_uuid": "u1", "content": "c"}
+            )
+
+
+def test_regression_set_block_properties_denies_private():
+    with _priv(), _api_with_block_page("Private/x"), \
+            patch("mcp_logseq.tools._db_mode", True):
+        with pytest.raises(AccessDenied):
+            SetBlockPropertiesToolHandler().run_tool(
+                {"block_uuid": "u1", "properties": {"k": "v"}}
+            )
+
+
+def test_regression_rename_page_denies_when_old_private():
+    with _priv():
+        with pytest.raises(AccessDenied):
+            RenamePageToolHandler().run_tool(
+                {"old_name": "Private/x", "new_name": "Public/x"}
+            )
+
+
+def test_regression_rename_page_denies_when_new_private():
+    with _priv():
+        with pytest.raises(AccessDenied):
+            RenamePageToolHandler().run_tool(
+                {"old_name": "Public/x", "new_name": "Private/x"}
+            )
+
+
+# =============================================================================
+# Task 5 Step 2a: --read-only unregisters genuine write tools only.
+# =============================================================================
+
+_GENUINE_WRITE_TOOLS = {
+    "create_page",
+    "update_page",
+    "delete_page",
+    "rename_page",
+    "update_block",
+    "delete_block",
+    "insert_nested_block",
+    "set_block_properties",
+}
+
+
+def test_read_only_unregisters_all_write_tools():
+    from mcp_logseq.server import build_app
+
+    _, handlers = build_app(read_only=True)
+    for name in _GENUINE_WRITE_TOOLS:
+        assert name not in handlers, f"{name} must be absent under read_only"
+
+
+def test_read_only_keeps_read_tools():
+    from mcp_logseq.server import build_app
+
+    _, handlers = build_app(read_only=True)
+    for name in [
+        "list_pages",
+        "get_page_content",
+        "get_block",
+        "search",
+        "query",
+        "find_pages_by_property",
+        "get_pages_from_namespace",
+        "get_pages_tree_from_namespace",
+        "get_page_backlinks",
+    ]:
+        assert name in handlers, f"read tool {name} must remain under read_only"
+
+
+def test_default_build_app_registers_write_tools():
+    from mcp_logseq.server import build_app
+
+    _, handlers = build_app()
+    for name in _GENUINE_WRITE_TOOLS:
+        assert name in handlers, f"{name} must be present by default"
+
+
+def test_read_only_keeps_sync_and_vector_tools(monkeypatch, tmp_path):
+    """sync_vector_db is NOT a genuine write tool; vector tools stay registered."""
+    pytest.importorskip("mcp_logseq.vector.index")
+
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({
+        "logseq_graph_path": str(tmp_path),
+        "vector": {
+            "enabled": True,
+            "db_path": str(tmp_path / "db"),
+            "embedder": {"provider": "ollama", "model": "nomic-embed-text"},
+        },
+    }))
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", str(path))
+
+    from mcp_logseq.server import build_app
+
+    _, handlers = build_app(read_only=True)
+    for name in ["vector_search", "vector_db_status", "sync_vector_db"]:
+        assert name in handlers, f"{name} must remain under read_only"
+
+
+# =============================================================================
+# Task 5 Step 2b: tag-on-write — writes to a tag-excluded EXISTING page in an
+# ALLOWED namespace must be denied. create_page is exempt (no prior tags).
+# =============================================================================
+
+
+def _tagged_page_api(tag="keys"):
+    """Mock _make_api so get_page_content returns a page carrying ``tag``."""
+    fake = Mock()
+    fake.get_page_content.return_value = {
+        "page": {"originalName": "work/secrets", "properties": {"tags": [tag]}},
+        "blocks": [],
+    }
+    fake.get_block_page_name.return_value = "work/secrets"
+    return patch("mcp_logseq.tools._make_api", return_value=fake)
+
+
+def _tags_excluded(tag="keys"):
+    return patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=[],
+        _exclude_namespaces=[],
+        _exclude_tags=[tag],
+    )
+
+
+def test_update_page_denies_tag_excluded_existing_page():
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            UpdatePageToolHandler().run_tool(
+                {"page_name": "work/secrets", "content": "c"}
+            )
+
+
+def test_delete_page_denies_tag_excluded_existing_page():
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            DeletePageToolHandler().run_tool({"page_name": "work/secrets"})
+
+
+def test_update_block_denies_tag_excluded_owning_page():
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            UpdateBlockToolHandler().run_tool({"block_uuid": "u1", "content": "c"})
+
+
+def test_delete_block_denies_tag_excluded_owning_page():
+    with _tags_excluded(), _tagged_page_api():
+        with pytest.raises(AccessDenied):
+            DeleteBlockToolHandler().run_tool({"block_uuid": "u1"})
+
+
+def test_set_block_properties_denies_tag_excluded_owning_page():
+    with _tags_excluded(), _tagged_page_api(), \
+            patch("mcp_logseq.tools._db_mode", True):
+        with pytest.raises(AccessDenied):
+            SetBlockPropertiesToolHandler().run_tool(
+                {"block_uuid": "u1", "properties": {"k": "v"}}
+            )
+
+
+def test_create_page_exempt_from_tag_on_write():
+    """create_page must NOT fetch/inspect prior tags — a new page has none."""
+    fake = Mock()
+    fake.page_exists.return_value = False
+    fake.create_page_with_blocks.return_value = {"name": "work/fresh"}
+    with _tags_excluded(), patch("mcp_logseq.tools._make_api", return_value=fake):
+        # Should not raise on tag grounds (namespace allows it).
+        CreatePageToolHandler().run_tool({"title": "work/fresh", "content": "c"})
+        fake.get_page_content.assert_not_called()
+
+
 def test_vector_search_drops_tag_excluded_chunk(monkeypatch):
     """A #keys chunk in the shared DB must not surface when 'keys' is excluded."""
     pytest.importorskip("mcp_logseq.vector.index")

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -812,6 +812,43 @@ def test_db_search_blocks_pass_when_no_rules():
         fake.resolve_page_uuids.assert_not_called()
 
 
+def test_db_search_fails_closed_when_list_pages_raises_with_rules():
+    """Fail-closed: if list_pages() throws while a rule is active, the search
+    must NOT surface DB-mode block content (it returns an error instead of an
+    unfiltered, degraded result set)."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "secret AKIA-leak", "uuid": "blk-1", "page": "uuid-fin"},
+        ],
+    }
+    fake.list_pages.side_effect = RuntimeError("api down")
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "x"})[0].text
+        assert "AKIA-leak" not in out
+        assert "Search failed" in out
+
+
+def test_search_no_rules_unaffected_by_list_pages():
+    """Control: with NO rules, _build_excluded_page_names returns early and never
+    calls list_pages, so a list_pages fault cannot break search."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [
+            {"content": "ordinary visible block", "uuid": "blk-1", "page": "uuid-1"},
+        ],
+    }
+    fake.list_pages.side_effect = RuntimeError("api down")
+    with _ns(), \
+            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "block"})[0].text
+        assert "ordinary visible block" in out
+        fake.list_pages.assert_not_called()
+
+
 # =============================================================================
 # LEAK 2: tag-only DSL query profile must filter block results whose owning
 # page is TAG-excluded (no namespace rules set).
@@ -854,6 +891,27 @@ def test_query_blocks_pass_when_no_rules_tag_axis():
         out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
         assert "anything" in out
         fake.get_page_content.assert_not_called()
+
+
+def test_query_tag_fetch_deduped_per_owning_page():
+    """Two blocks from the SAME owning page must trigger get_page_content only
+    once within a single query run (per-request memo)."""
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "alpha", "page": {"originalName": "notes"}},
+        {"content": "beta", "page": {"originalName": "notes"}},
+    ]
+    fake.get_page_content.return_value = {"page": {"properties": {}}}
+    with patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=[],
+        _exclude_namespaces=[],
+        _exclude_tags=["keys"],
+    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
+        assert "alpha" in out
+        assert "beta" in out
+        assert fake.get_page_content.call_count == 1
 
 
 # =============================================================================

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -297,6 +297,38 @@ def test_block_allowed_when_no_rules():
         fake.get_block_page_name.assert_not_called()
 
 
+def test_get_block_denies_when_page_tag_excluded():
+    """A block in an ALLOWED namespace but whose owning page carries an excluded
+    tag (#keys) must be denied. Namespace passes; the tag guard must catch it."""
+    fake = Mock()
+    fake.get_block_page_name.return_value = "work/vault"  # allowed namespace
+    fake.get_page_content.return_value = {"page": {"properties": {"tags": ["keys"]}}}
+    with patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=["work"],
+        _exclude_namespaces=[],
+        _exclude_tags=["keys"],
+    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+        with pytest.raises(AccessDenied):
+            GetBlockToolHandler().run_tool({"block_uuid": "u-tag"})
+
+
+def test_get_block_allowed_when_page_not_tag_excluded():
+    """Control: a block whose owning page has no excluded tag still returns."""
+    fake = Mock()
+    fake.get_block_page_name.return_value = "work/vault"
+    fake.get_page_content.return_value = {"page": {"properties": {"tags": ["notes"]}}}
+    fake.get_block.return_value = {"content": "visible block content", "children": []}
+    with patch.multiple(
+        "mcp_logseq.tools",
+        _include_namespaces=["work"],
+        _exclude_namespaces=[],
+        _exclude_tags=["keys"],
+    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = GetBlockToolHandler().run_tool({"block_uuid": "u-ok"})[0].text
+        assert "visible block content" in out
+
+
 def test_set_block_properties_denies():
     # set_block_properties only runs in DB mode; patch _db_mode so the handler
     # reaches the enforcement call rather than returning the DB-mode guard early.
@@ -384,6 +416,65 @@ def test_search_excludes_blocked_namespace_pages():
         )
         assert "finance/q3" in names
         assert "work/x" not in names
+
+
+def test_markdown_search_suppresses_unidentified_blocks_when_excluding_text():
+    """Markdown-mode 'blocks' carry block/content but no page id. When any
+    exclusion is active they cannot be verified safe, so the whole blocks
+    section must be suppressed in text output (mirrors the snippets guard)."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [{"block/content": "secret api token AKIA-leak"}],
+        "pages": ["work/x"],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "finance/q3", "properties": {}},
+        {"originalName": "work/x", "properties": {}},
+    ]
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "token"})[0].text
+        assert "AKIA-leak" not in out
+        assert "Content Blocks" not in out
+        assert "work/x" in out  # identified pages still surface
+
+
+def test_markdown_search_suppresses_unidentified_blocks_when_excluding_json():
+    """Same suppression must apply on the JSON output path."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [{"block/content": "secret api token AKIA-leak"}],
+        "pages": ["work/x"],
+    }
+    fake.list_pages.return_value = [
+        {"originalName": "finance/q3", "properties": {}},
+        {"originalName": "work/x", "properties": {}},
+    ]
+    with _ns(exclude=["finance"]), \
+            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "token", "format": "json"})[0].text
+        assert "AKIA-leak" not in out
+        parsed = json.loads(out)
+        assert "blocks" not in parsed  # unidentified blocks omitted
+        assert parsed["pages"] == ["work/x"]
+
+
+def test_markdown_search_shows_blocks_when_no_exclusion():
+    """Control: with no exclusion active, the blocks section still appears."""
+    fake = Mock()
+    fake.search_content.return_value = {
+        "blocks": [{"block/content": "ordinary visible block"}],
+        "pages": ["work/x"],
+    }
+    fake.list_pages.return_value = []
+    with _ns(), \
+            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = SearchToolHandler().run_tool({"query": "block"})[0].text
+        assert "ordinary visible block" in out
+        assert "Content Blocks" in out
 
 
 def test_query_hides_blocked_page_objects():

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -525,6 +525,26 @@ def test_query_filters_blocks_via_api_page_resolution():
     with _ns(exclude=["finance"]), patch("mcp_logseq.tools._make_api", return_value=fake):
         out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
         assert "secret data" not in out
+        # Assert the empty branch was taken — not silently swallowed elsewhere.
+        assert "No results" in out
+
+
+def test_query_filters_block_with_bare_uuid_page_ref():
+    """A block whose inline 'page' is a bare UUID string must be resolved, not
+    trusted. Under an exclude-only policy a raw UUID matches no rule, so trusting
+    it would fail OPEN. The UUID must resolve to its real (denied) page name."""
+    denied_uuid = "12345678-1234-1234-1234-123456789abc"
+    fake = Mock()
+    fake.query_dsl.return_value = [
+        {"content": "secret salary data", "page": denied_uuid},
+    ]
+    fake.resolve_page_uuids.return_value = {denied_uuid: "Private/Secret"}
+    with _ns(exclude=["private"]), patch("mcp_logseq.tools._make_api", return_value=fake):
+        out = QueryToolHandler().run_tool({"query": "(page-tags)"})[0].text
+        assert "secret salary data" not in out
+        assert denied_uuid not in out
+        assert "No results" in out
+        fake.resolve_page_uuids.assert_called_once_with([denied_uuid])
 
 
 def test_query_block_denied_when_page_unresolvable_and_rules_set():
@@ -537,6 +557,9 @@ def test_query_block_denied_when_page_unresolvable_and_rules_set():
     with _ns(include=["work"]), patch("mcp_logseq.tools._make_api", return_value=fake):
         out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
         assert "unverifiable block" not in out
+        # Tighten: assert the tool reported the empty branch, so a bug that
+        # swallows the item into the non-empty render path cannot pass.
+        assert "No results" in out
 
 
 def test_query_block_json_format_also_filtered():

--- a/tests/unit/vector/test_index.py
+++ b/tests/unit/vector/test_index.py
@@ -138,72 +138,45 @@ class TestVectorSearchReadOnly:
             mock_sm.return_value.save.assert_not_called()
 
 
-class TestSyncVectorDBSubprocess:
-    """sync_vector_db delegates to logseq-sync subprocess."""
+class TestSyncVectorDBInertPointer:
+    """sync_vector_db no longer spawns a subprocess; it points to external logseq-sync."""
 
-    def test_sync_calls_subprocess_once(self):
+    def test_sync_does_not_invoke_subprocess(self):
         config = _make_config()
         handler = SyncVectorDBToolHandler(config)
 
-        with patch("mcp_logseq.vector.index.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(
-                returncode=0,
-                stdout="Done in 100ms: +5 added, ~2 updated, -1 deleted, 10 skipped",
-                stderr="",
-            )
-
+        with patch("subprocess.run") as mock_run:
             results = handler.run_tool({})
 
-            call_args = mock_sub.run.call_args
-            cmd = call_args[0][0]
-            assert "--once" in cmd
-            assert "--rebuild" not in cmd
-            assert "Done in 100ms" in results[0].text
+            # The single-writer principle: MCP never spawns a sync process.
+            mock_run.assert_not_called()
+            assert "logseq-sync" in results[0].text
 
-    def test_sync_calls_subprocess_rebuild(self):
+    def test_sync_message_lists_external_flags(self):
         config = _make_config()
         handler = SyncVectorDBToolHandler(config)
 
-        with patch("mcp_logseq.vector.index.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(
-                returncode=0,
-                stdout="Done in 5000ms: +100 added, ~0 updated, -0 deleted, 0 skipped",
-                stderr="",
-            )
+        text = handler.run_tool({})[0].text
+        assert "logseq-sync --once" in text
+        assert "logseq-sync --watch" in text
+        assert "logseq-sync --rebuild" in text
 
+    def test_sync_ignores_rebuild_arg(self):
+        config = _make_config()
+        handler = SyncVectorDBToolHandler(config)
+
+        with patch("subprocess.run") as mock_run:
             results = handler.run_tool({"rebuild": True})
+            mock_run.assert_not_called()
+            assert "logseq-sync" in results[0].text
 
-            call_args = mock_sub.run.call_args
-            cmd = call_args[0][0]
-            assert "--rebuild" in cmd
-            assert "--once" not in cmd
-
-    def test_sync_reports_subprocess_failure(self):
+    def test_description_mentions_external_host(self):
         config = _make_config()
         handler = SyncVectorDBToolHandler(config)
 
-        with patch("mcp_logseq.vector.index.subprocess") as mock_sub:
-            mock_sub.run.return_value = MagicMock(
-                returncode=1,
-                stdout="",
-                stderr="Error: Embedder changed from 'x' to 'y'",
-            )
-
-            results = handler.run_tool({})
-            assert "Sync failed" in results[0].text
-            assert "Embedder changed" in results[0].text
-
-    def test_sync_reports_timeout(self):
-        import subprocess
-        config = _make_config()
-        handler = SyncVectorDBToolHandler(config)
-
-        with patch("mcp_logseq.vector.index.subprocess") as mock_sub:
-            mock_sub.TimeoutExpired = subprocess.TimeoutExpired
-            mock_sub.run.side_effect = subprocess.TimeoutExpired(cmd="logseq-sync", timeout=600)
-
-            results = handler.run_tool({})
-            assert "timed out" in results[0].text
+        desc = handler.get_tool_description().description
+        assert "logseq-sync" in desc
+        assert "host that owns the DB" in desc
 
 
 class TestVectorDBStatusReadOnly:

--- a/tests/unit/vector/test_index.py
+++ b/tests/unit/vector/test_index.py
@@ -62,7 +62,9 @@ class TestVectorSearchReadOnly:
 
             # Should report staleness but NOT trigger any sync
             assert "2 pages changed since last sync" in results[0].text
-            assert "sync_vector_db" in results[0].text
+            # Points to the external writer, never the inert sync_vector_db tool
+            assert "logseq-sync --watch" in results[0].text
+            assert "sync_vector_db" not in results[0].text
             # Should NOT call save (no migration, no sync)
             mock_sm.return_value.save.assert_not_called()
 
@@ -141,16 +143,19 @@ class TestVectorSearchReadOnly:
 class TestSyncVectorDBInertPointer:
     """sync_vector_db no longer spawns a subprocess; it points to external logseq-sync."""
 
-    def test_sync_does_not_invoke_subprocess(self):
+    def test_module_does_not_import_subprocess(self):
+        # Single-writer principle: this module must not be able to spawn a sync.
+        # Reintroducing `import subprocess` (the only way to spawn here) fails this.
+        import mcp_logseq.vector.index as idx
+
+        assert not hasattr(idx, "subprocess")
+
+    def test_sync_returns_pointer_message(self):
         config = _make_config()
         handler = SyncVectorDBToolHandler(config)
 
-        with patch("subprocess.run") as mock_run:
-            results = handler.run_tool({})
-
-            # The single-writer principle: MCP never spawns a sync process.
-            mock_run.assert_not_called()
-            assert "logseq-sync" in results[0].text
+        results = handler.run_tool({})
+        assert "logseq-sync" in results[0].text
 
     def test_sync_message_lists_external_flags(self):
         config = _make_config()


### PR DESCRIPTION
## Summary

I added an HTTP/SSE (Streamable HTTP) transport so `mcp-logseq` can run as a networked service on the host that owns the data, while a sandboxed client reaches it only over HTTP with no filesystem or Logseq-API access. This turns the existing namespace/tag access control into a real, server-side security boundary.

## What's included

- **HTTP transport**: Streamable HTTP ASGI app mounted at `/mcp`, with bearer-token auth (`MCP_HTTP_AUTH_TOKEN`). Auth is pure-ASGI (streaming-safe), constant-time, and rejects duplicate/non-ASCII Authorization headers.
- **CLI**: `mcp-logseq --transport stdio|http --host --port --read-only`. Defaults to stdio bound to loopback; existing stdio users are unaffected.
- **Full ACL audit**: every content-returning tool now enforces the namespace + tag guard over the HTTP surface. This closed several real leaks found during review: DSL `query` block exfiltration, a bare-UUID fail-open, the `vector_search` tag gap, `get_block` missing its tag guard, and markdown-mode search emitting unidentifiable blocks.
- **Write policy**: `--read-only` unregisters the 8 mutating tools; a tag-on-write guard protects existing tag-excluded pages across all 7 write handlers (fail-closed on fetch error). Namespace gating from #65 is preserved, not re-added.
- **Single-writer sync**: `sync_vector_db` is now inert and points operators to an external `logseq-sync` process that solely owns the vector DB.
- **Docs**: per-profile multi-instance run pattern, the separate sync writer, and the security model (including the tag case-sensitivity operator note).

## Isolation model

Multi-instance, not multi-tenant: one process per profile (shared data config + a per-process env block + token + port). The profile boundary is the process boundary, so another profile's config is never even loaded.

## Test plan

- [x] Full suite passes (547 tests), including new unit + integration coverage for auth, profile isolation, read-only enforcement, and the inert sync stub
- [x] Manual smoke test: run `--transport http` with a token, confirm 401 without bearer and a working MCP handshake with it
- [x] Manual smoke test: confirm stdio mode still works unchanged

