### PR TITLE
feat: native TLS serving + insecure-bind guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ When serving multiple clients over HTTP, isolation rests on a few guarantees:
 
 - **ACL is enforced server-side, before any bytes leave the process.** Blocked pages are filtered out of listings/search and denied on direct read/write — a client never receives content it isn't scoped to.
 - **Bearer auth.** Every HTTP request must carry `Authorization: Bearer <MCP_HTTP_AUTH_TOKEN>`; unauthenticated requests are rejected.
-- **Loopback binding.** Default `--host 127.0.0.1`; never `0.0.0.0`.
+- **Loopback binding.** Default `--host 127.0.0.1` (loopback). Non-loopback binds are refused over plain HTTP — they require TLS (`--tls-cert`/`--tls-key`) or an explicit `--insecure` (see [Step 3](#step-3--encrypt-anything-past-loopback)).
 - **Process-boundary isolation.** Multi-instance means one profile's config (token, namespace scope, excluded tags) is never loaded by another process.
 - **Read tools** enforce namespace allow/deny *or* tag exclusion. **Write tools** enforce namespace gating plus tag-on-write checks against the existing page, so a write can't slip into a blocked namespace or onto an excluded page.
 - **Tag matching is case-SENSITIVE; namespace matching is case-INSENSITIVE.** Namespaces match regardless of case (`work` matches `Work/Projects`), but `LOGSEQ_EXCLUDE_TAGS` / `vector.exclude_tags` must match the **stored** tag casing exactly. Logseq typically stores tags lowercased, so `LOGSEQ_EXCLUDE_TAGS=Secret` will **not** exclude a page tagged `secret`. Match the casing as stored, or a page you meant to hide stays visible.

--- a/README.md
+++ b/README.md
@@ -285,9 +285,10 @@ mcp-logseq --transport http --host 127.0.0.1 --port 12320
 ```
 
 - `--transport {stdio,http}` — default `stdio`.
-- `--host` — default `127.0.0.1` (loopback). **Never bind to `0.0.0.0`.** ACL is enforced server-side, but binding to a public interface would still expose the auth-token surface to the network; keep it on loopback or a host-internal interface.
+- `--host` — default `127.0.0.1` (loopback). Binding a non-loopback host over plain HTTP is **refused** unless you supply TLS or pass `--insecure`; see [Step 3 — encrypt anything past loopback](#step-3--encrypt-anything-past-loopback).
 - `--port` — default `12320`.
 - `--read-only` — unregisters the 8 write tools (see [Security model](#-security-model)); read tools and the vector tools remain.
+- `--tls-cert` / `--tls-key` — serve native HTTPS; see [Step 3](#step-3--encrypt-anything-past-loopback).
 
 HTTP mode **requires** `MCP_HTTP_AUTH_TOKEN`; the server exits if it is missing. Clients authenticate with `Authorization: Bearer <token>` and target the MCP endpoint at **`/mcp`**. (A bare POST to `/mcp` issues a `307` redirect to `/mcp/`; point clients at `/mcp` and follow redirects, or use `/mcp/` directly.)
 
@@ -332,6 +333,38 @@ LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --once
 ```
 
 `logseq-sync` reads **no ACL env** — only the `vector` block and graph path from the data file. (`--rebuild` drops and re-indexes from scratch; `--status` prints a staleness report.) The reader profiles open the same `db_path` read-only and never run sync: the MCP `sync_vector_db` tool is inert and simply points operators at this external writer.
+
+#### Step 3 — encrypt anything past loopback
+
+> **The bearer token and all content travel as plaintext over plain HTTP.** Anything reachable beyond loopback must be encrypted — either native TLS on the instance, or a TLS-terminating reverse proxy in front of a loopback-bound instance.
+
+To enforce this, the server **refuses to bind a non-loopback host over plain HTTP**. A host outside the loopback set (`127.0.0.1`, `localhost`, `::1`) requires one of:
+
+- **Native TLS** — pass `--tls-cert` and `--tls-key`. TLS is allowed on any host.
+- **A TLS-terminating reverse proxy** in front, with the instance bound to a loopback address (recommended — see below).
+- **`--insecure`** — consciously accept an unencrypted non-loopback bind. Only sane on a trusted network or already behind a TLS proxy.
+
+Loopback binds over plain HTTP need no opt-in; that remains the default.
+
+**Native TLS** wraps the instance directly in HTTPS (uvicorn's `ssl_certfile`/`ssl_keyfile`):
+
+```bash
+mcp-logseq --transport http --port 12320 \
+  --tls-cert /path/cert.pem --tls-key /path/key.pem
+```
+
+`--tls-cert` and `--tls-key` must be supplied **together** (both or neither, else the server exits), and both files **must exist** at startup. For the certificate itself: use [`mkcert`](https://github.com/FiloSottile/mkcert) or a self-signed cert for host-internal/dev use, or [Let's Encrypt](https://letsencrypt.org/) when the instance is reachable on a public DNS name. The per-profile env blocks from [Step 1](#step-1--one-instance-per-profile) are unchanged — TLS just changes the wire, not the profile.
+
+**Recommended production path — reverse proxy with automatic HTTPS.** Bind the instance to loopback and let a proxy such as [Caddy](https://caddyserver.com/) terminate TLS (it obtains and renews Let's Encrypt certificates automatically):
+
+```caddyfile
+# Caddyfile — automatic HTTPS in front of a loopback-bound instance
+logseq.example.com {
+    reverse_proxy 127.0.0.1:12320
+}
+```
+
+With the instance running as `mcp-logseq --transport http --port 12320` (loopback default, no `--insecure` needed), clients reach it over HTTPS at `logseq.example.com` while the unencrypted hop stays inside the host.
 
 ### Alternative Setup Methods
 

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -15,7 +15,25 @@ def parse_args(argv=None):
         action="store_true",
         help="Disable write tools (create/update/delete/rename for pages and blocks).",
     )
+    p.add_argument("--tls-cert", default=None,
+                   help="Path to a PEM TLS certificate. Enables HTTPS (requires --tls-key).")
+    p.add_argument("--tls-key", default=None,
+                   help="Path to the PEM TLS private key (requires --tls-cert).")
     return p.parse_args(argv)
+
+
+def _validate_http_options(args) -> None:
+    """Validate TLS options for the http transport. Raises SystemExit on misconfig.
+
+    Task 2 extends this with the insecure-bind guardrail.
+    """
+    import os
+    if (args.tls_cert is None) != (args.tls_key is None):
+        raise SystemExit("--tls-cert and --tls-key must be provided together")
+    if args.tls_cert is not None:
+        for label, path in (("--tls-cert", args.tls_cert), ("--tls-key", args.tls_key)):
+            if not os.path.isfile(path):
+                raise SystemExit(f"{label} file not found: {path}")
 
 
 def main():
@@ -33,9 +51,11 @@ def main():
         token = os.environ.get("MCP_HTTP_AUTH_TOKEN")
         if not token:
             raise SystemExit("MCP_HTTP_AUTH_TOKEN is required for --transport http")
+        _validate_http_options(args)
         from .transport import http
 
-        http.run_http(args.host, args.port, token, read_only=args.read_only)
+        http.run_http(args.host, args.port, token, read_only=args.read_only,
+                      tls_cert=args.tls_cert, tls_key=args.tls_key)
 
 
 # Optionally expose other important items at package level.

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -19,6 +19,10 @@ def parse_args(argv=None):
                    help="Path to a PEM TLS certificate. Enables HTTPS (requires --tls-key).")
     p.add_argument("--tls-key", default=None,
                    help="Path to the PEM TLS private key (requires --tls-cert).")
+    p.add_argument("--insecure", action="store_true",
+                   help=("Allow binding a non-loopback host over plain HTTP. Without TLS "
+                         "the bearer token and all content travel unencrypted — only use "
+                         "on a trusted network or behind a TLS-terminating reverse proxy."))
     return p.parse_args(argv)
 
 
@@ -34,6 +38,17 @@ def _validate_http_options(args) -> None:
         for label, path in (("--tls-cert", args.tls_cert), ("--tls-key", args.tls_key)):
             if not os.path.isfile(path):
                 raise SystemExit(f"{label} file not found: {path}")
+
+    _LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+    tls_enabled = args.tls_cert is not None
+    if args.host not in _LOOPBACK_HOSTS and not tls_enabled and not args.insecure:
+        raise SystemExit(
+            f"Refusing to bind {args.host} over plain HTTP: the bearer token and "
+            f"all content would travel unencrypted. Either provide --tls-cert/"
+            f"--tls-key, put a TLS-terminating reverse proxy in front and bind a "
+            f"loopback address, or pass --insecure to override (not recommended "
+            f"outside a trusted network)."
+        )
 
 
 def main():

--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -27,9 +27,11 @@ def parse_args(argv=None):
 
 
 def _validate_http_options(args) -> None:
-    """Validate TLS options for the http transport. Raises SystemExit on misconfig.
+    """Validate HTTP transport options. Raises SystemExit on misconfig.
 
-    Task 2 extends this with the insecure-bind guardrail.
+    Checks that --tls-cert/--tls-key are supplied together, that both files
+    exist on disk, and that a non-loopback host is not served over plain HTTP
+    without --insecure.
     """
     import os
     if (args.tls_cert is None) != (args.tls_key is None):

--- a/src/mcp_logseq/transport/http.py
+++ b/src/mcp_logseq/transport/http.py
@@ -49,11 +49,23 @@ def create_asgi_app(auth_token: str, read_only: bool = False) -> Starlette:
 
 
 def run_http(
-    host: str, port: int, auth_token: str, read_only: bool = False
+    host: str,
+    port: int,
+    auth_token: str,
+    read_only: bool = False,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
 ) -> None:
-    """Run the HTTP transport with uvicorn (imported lazily)."""
+    """Run the HTTP transport with uvicorn (imported lazily).
+
+    When tls_cert/tls_key are provided, uvicorn serves over HTTPS.
+    """
     import uvicorn
 
     uvicorn.run(
-        create_asgi_app(auth_token, read_only=read_only), host=host, port=port
+        create_asgi_app(auth_token, read_only=read_only),
+        host=host,
+        port=port,
+        ssl_certfile=tls_cert,
+        ssl_keyfile=tls_key,
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -119,6 +119,40 @@ def test_validate_http_options_missing_cert_file(tmp_path):
         _validate_http_options(args)
 
 
+def test_parse_args_insecure_default_false():
+    args = parse_args(["--transport", "http"])
+    assert args.insecure is False
+
+
+def test_validate_refuses_non_loopback_plain_http():
+    from mcp_logseq import _validate_http_options
+    args = parse_args(["--transport", "http", "--host", "0.0.0.0"])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
+def test_validate_allows_non_loopback_with_insecure():
+    from mcp_logseq import _validate_http_options
+    args = parse_args(["--transport", "http", "--host", "0.0.0.0", "--insecure"])
+    _validate_http_options(args)  # must not raise
+
+
+def test_validate_allows_non_loopback_with_tls(tmp_path):
+    from mcp_logseq import _validate_http_options
+    cert = tmp_path / "c.pem"; cert.write_text("x")
+    key = tmp_path / "k.pem"; key.write_text("x")
+    args = parse_args(["--transport", "http", "--host", "10.0.0.5",
+                       "--tls-cert", str(cert), "--tls-key", str(key)])
+    _validate_http_options(args)  # must not raise
+
+
+def test_validate_allows_loopback_plain_http():
+    from mcp_logseq import _validate_http_options
+    for host in ("127.0.0.1", "localhost", "::1"):
+        args = parse_args(["--transport", "http", "--host", host])
+        _validate_http_options(args)  # must not raise
+
+
 def test_run_http_passes_ssl_to_uvicorn(monkeypatch):
     import mcp_logseq.transport.http as http_mod
     calls = {}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -119,6 +119,14 @@ def test_validate_http_options_missing_cert_file(tmp_path):
         _validate_http_options(args)
 
 
+def test_validate_http_options_missing_key_file(tmp_path):
+    from mcp_logseq import _validate_http_options
+    cert = tmp_path / "c.pem"; cert.write_text("x")
+    args = parse_args(["--transport", "http", "--tls-cert", str(cert), "--tls-key", str(tmp_path / "nope.pem")])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
 def test_parse_args_insecure_default_false():
     args = parse_args(["--transport", "http"])
     assert args.insecure is False

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -59,7 +59,12 @@ def test_main_http_with_token_calls_run_http(monkeypatch):
 
     mcp_logseq.main()
 
-    assert calls == [(("127.0.0.1", 12320, "secret-token"), {"read_only": False})]
+    assert calls == [
+        (
+            ("127.0.0.1", 12320, "secret-token"),
+            {"read_only": False, "tls_cert": None, "tls_key": None},
+        )
+    ]
 
 
 def test_main_http_read_only_threaded(monkeypatch):
@@ -79,4 +84,54 @@ def test_main_http_read_only_threaded(monkeypatch):
 
     mcp_logseq.main()
 
-    assert calls == [(("127.0.0.1", 12320, "secret-token"), {"read_only": True})]
+    assert calls == [
+        (
+            ("127.0.0.1", 12320, "secret-token"),
+            {"read_only": True, "tls_cert": None, "tls_key": None},
+        )
+    ]
+
+
+def test_parse_args_tls_flags_default_none():
+    args = parse_args(["--transport", "http"])
+    assert args.tls_cert is None
+    assert args.tls_key is None
+
+
+def test_parse_args_tls_flags_parsed():
+    args = parse_args(["--transport", "http", "--tls-cert", "/c.pem", "--tls-key", "/k.pem"])
+    assert args.tls_cert == "/c.pem"
+    assert args.tls_key == "/k.pem"
+
+
+def test_validate_http_options_requires_both_tls_files():
+    from mcp_logseq import _validate_http_options
+    args = parse_args(["--transport", "http", "--tls-cert", "/c.pem"])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
+def test_validate_http_options_missing_cert_file(tmp_path):
+    from mcp_logseq import _validate_http_options
+    key = tmp_path / "k.pem"; key.write_text("x")
+    args = parse_args(["--transport", "http", "--tls-cert", str(tmp_path / "nope.pem"), "--tls-key", str(key)])
+    with pytest.raises(SystemExit):
+        _validate_http_options(args)
+
+
+def test_run_http_passes_ssl_to_uvicorn(monkeypatch):
+    import mcp_logseq.transport.http as http_mod
+    calls = {}
+    monkeypatch.setattr("uvicorn.run", lambda app, **kw: calls.update(kw))
+    http_mod.run_http("127.0.0.1", 12320, "tok", tls_cert="/c.pem", tls_key="/k.pem")
+    assert calls["ssl_certfile"] == "/c.pem"
+    assert calls["ssl_keyfile"] == "/k.pem"
+
+
+def test_run_http_no_tls_passes_none(monkeypatch):
+    import mcp_logseq.transport.http as http_mod
+    calls = {}
+    monkeypatch.setattr("uvicorn.run", lambda app, **kw: calls.update(kw))
+    http_mod.run_http("127.0.0.1", 12320, "tok")
+    assert calls.get("ssl_certfile") is None
+    assert calls.get("ssl_keyfile") is None


### PR DESCRIPTION
> **Stacked on #69** — this builds on the HTTP transport from that PR, so its base is `feat/http-secure-serving`. GitHub will retarget it to `main` automatically once #69 merges.

## Summary

This adds encryption options to the HTTP transport so publishing the tool doesn't hand downstream users a silent footgun. Plain HTTP sends the bearer token and all content in cleartext, so anything served past loopback needs to be encrypted.

- **Native TLS**: `--tls-cert`/`--tls-key` are passed to uvicorn (`ssl_certfile`/`ssl_keyfile`), so `--transport http` can serve HTTPS directly. Both flags are required together and the files must exist.
- **Insecure-bind guardrail**: binding a non-loopback host (anything other than `127.0.0.1`/`localhost`/`::1`) over plain HTTP is refused unless `--insecure` is explicitly passed. TLS on any host is fine; loopback plain HTTP stays friction-free (today's default).
- **Docs**: native TLS usage, the guardrail, and a Caddy reverse-proxy example (the recommended production path with automatic HTTPS in front of a loopback-bound instance).

Validation lives in a single `_validate_http_options` helper (TLS pair → file existence → bind guardrail). Default behavior (stdio, or plain HTTP on loopback) is unchanged.

## Test plan

- [x] Full suite passes (569 tests), including new CLI tests for the TLS pass-through, both-or-neither / file-existence validation, and every bind-guardrail combination
- [x] Manual: serve with `--tls-cert/--tls-key`, confirm HTTPS and a working bearer handshake
- [x] Manual: confirm `--host 0.0.0.0` over plain HTTP is refused without `--insecure`

