### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-06-19
+
+### Added
+
+- **HTTP/SSE transport** — run the server as a networked service with `--transport http`, secured by bearer-token auth (`MCP_HTTP_AUTH_TOKEN`). A sandboxed or remote client can now reach Logseq over the network with no filesystem mount or direct Logseq-API access, turning the namespace/tag access control into a real server-side security boundary (#69)
+- **Per-profile multi-instance serving** — run one process per profile (a shared data config file + a per-process env block of namespace/tag/token + its own port). Adds `--read-only` to disable all write tools, and tag-on-write guards so writes can't land on a tag-excluded page (#69)
+- **Native TLS** — `--tls-cert`/`--tls-key` serve HTTPS directly (uvicorn `ssl_certfile`/`ssl_keyfile`), plus a bind guardrail that refuses non-loopback plain-HTTP binds unless you pass `--insecure` (#71)
+- New deployment guide at [docs/SERVING.md](docs/SERVING.md) — security model, the per-profile pattern, the separate `logseq-sync` writer, and TLS / reverse-proxy setup
+
+### Changed
+
+- `sync_vector_db` is now inert — the vector DB is owned by a single external `logseq-sync` writer process; the tool points operators at it instead of spawning a sync (#69)
+
+### Fixed
+
+- Block-level results from `search` (DB mode) and `query` (tag-only profiles) are now resolved to their owning page and filtered by the namespace/tag ACL, closing cases where restricted block content could surface in block-level results (#69)
+- The page-exclusion set now fails closed when ACL rules are active — if it can't be built, `search` returns an error instead of unfiltered results (#69)
+
 ## [1.7.0] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The server provides 16 tools with intelligent markdown parsing, plus 3 optional 
 The `create_page` and `update_page` tools now automatically convert markdown into Logseq's native block structure:
 
 **Markdown Input:**
-```markdown
+````markdown
 ---
 tags: [project, active]
 priority: high
@@ -159,7 +159,7 @@ Introduction paragraph here.
 def hello():
     print("Hello Logseq!")
 ```
-```
+````
 
 **Result:** Creates properly nested blocks with:
 - ✅ Page properties from YAML frontmatter (`tags`, `priority`)
@@ -212,7 +212,7 @@ If you hit the "already exists" error mid-ingest, use `get_page_content` to see 
 - **`LOGSEQ_INCLUDE_NAMESPACES`** (optional): Comma-separated namespace allow-list (e.g. `work,projects`). When set, **only** pages in these namespaces and their sub-pages are accessible — everything else, including top-level pages without a namespace, is hidden from listings/search and denied on direct access. See [Privacy & Access Control](#-privacy--access-control) below.
 - **`LOGSEQ_EXCLUDE_NAMESPACES`** (optional): Comma-separated namespace deny-list (e.g. `finance,work/secret`). These namespaces are always blocked, taking priority over the include list. See [Privacy & Access Control](#-privacy--access-control) below.
 - **`LOGSEQ_CONFIG_FILE`** (optional): Path to a shared JSON config file holding the graph path, ACL defaults, and the `vector` block. Env vars (`LOGSEQ_EXCLUDE_TAGS`, `LOGSEQ_INCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_NAMESPACES`) override the matching keys in this file.
-- **`MCP_HTTP_AUTH_TOKEN`** (required for `--transport http`): Bearer token clients must send as `Authorization: Bearer <token>`. The server refuses to start in HTTP mode without it. See [Serving over HTTP](#-serving-over-http-multi-profile) below.
+- **`MCP_HTTP_AUTH_TOKEN`** (required for `--transport http`): Bearer token clients must send as `Authorization: Bearer <token>`. The server refuses to start in HTTP mode without it. See [Serving over HTTP](docs/SERVING.md).
 
 ### Privacy & Access Control
 
@@ -263,108 +263,18 @@ LOGSEQ_EXCLUDE_NAMESPACES=work/secret,finance
 
 Matching is segment-based and case-insensitive: `work` matches `work` and `work/projects` but not `workshop`. The behavior mirrors `LOGSEQ_EXCLUDE_TAGS`: list/search results silently omit blocked pages; direct read, write, delete, and block operations return an access-denied error.
 
-**Known limitation:** access control is enforced at the **page** level. `search` and `query` filter out whole pages that are blocked, but individual blocks returned by a `query` DSL or by full-text `search` are not resolved back to their owning page, so a block belonging to a restricted page can still surface in those block-level results. Page listings, direct page/block access, backlinks, and vector search are all filtered; tighten DSL queries accordingly if this matters for your setup.
+Access control is enforced at the **page** level and applied across every tool: list/search/query results omit blocked pages, direct page/block access and backlinks are denied, and vector search is filtered. Block-level results from `search` and `query` are resolved back to their owning page, so a block belonging to a restricted page is filtered out of those results too.
 
-### 🔒 Security model
+### 🌐 Serving over HTTP, multi-profile & TLS
 
-When serving multiple clients over HTTP, isolation rests on a few guarantees:
-
-- **ACL is enforced server-side, before any bytes leave the process.** Blocked pages are filtered out of listings/search and denied on direct read/write — a client never receives content it isn't scoped to.
-- **Bearer auth.** Every HTTP request must carry `Authorization: Bearer <MCP_HTTP_AUTH_TOKEN>`; unauthenticated requests are rejected.
-- **Loopback binding.** Default `--host 127.0.0.1` (loopback). Non-loopback binds are refused over plain HTTP — they require TLS (`--tls-cert`/`--tls-key`) or an explicit `--insecure` (see [Step 3](#step-3--encrypt-anything-past-loopback)).
-- **Process-boundary isolation.** Multi-instance means one profile's config (token, namespace scope, excluded tags) is never loaded by another process.
-- **Read tools** enforce namespace allow/deny *or* tag exclusion. **Write tools** enforce namespace gating plus tag-on-write checks against the existing page, so a write can't slip into a blocked namespace or onto an excluded page.
-- **Tag matching is case-SENSITIVE; namespace matching is case-INSENSITIVE.** Namespaces match regardless of case (`work` matches `Work/Projects`), but `LOGSEQ_EXCLUDE_TAGS` / `vector.exclude_tags` must match the **stored** tag casing exactly. Logseq typically stores tags lowercased, so `LOGSEQ_EXCLUDE_TAGS=Secret` will **not** exclude a page tagged `secret`. Match the casing as stored, or a page you meant to hide stays visible.
-
-### 🌐 Serving over HTTP (multi-profile)
-
-By default the server speaks **stdio** — the local client spawns it as a subprocess. For serving sandboxed or remote clients (each one only allowed to see a slice of your graph), the server can also run as a long-lived **HTTP** process:
+By default the server speaks **stdio** — your client spawns it as a subprocess, and most users need nothing more. To serve **sandboxed or remote clients** over the network, `mcp-logseq` can run as a long-lived HTTP service with bearer auth, per-profile isolation, and TLS:
 
 ```bash
-mcp-logseq --transport http --host 127.0.0.1 --port 12320
+mcp-logseq --transport http --host 127.0.0.1 --port 12320   # requires MCP_HTTP_AUTH_TOKEN
 ```
 
-- `--transport {stdio,http}` — default `stdio`.
-- `--host` — default `127.0.0.1` (loopback). Binding a non-loopback host over plain HTTP is **refused** unless you supply TLS or pass `--insecure`; see [Step 3 — encrypt anything past loopback](#step-3--encrypt-anything-past-loopback).
-- `--port` — default `12320`.
-- `--read-only` — unregisters the 8 write tools (see [Security model](#-security-model)); read tools and the vector tools remain.
-- `--tls-cert` / `--tls-key` — serve native HTTPS; see [Step 3](#step-3--encrypt-anything-past-loopback).
+The full deployment guide — the server-side **security model**, the **per-profile multi-instance** pattern, the separate **`logseq-sync` writer**, and native **TLS** / reverse-proxy setup — lives in **[docs/SERVING.md](docs/SERVING.md)**. Non-loopback binds over plain HTTP are refused unless you supply TLS or pass `--insecure`.
 
-HTTP mode **requires** `MCP_HTTP_AUTH_TOKEN`; the server exits if it is missing. Clients authenticate with `Authorization: Bearer <token>` and target the MCP endpoint at **`/mcp`**. (A bare POST to `/mcp` issues a `307` redirect to `/mcp/`; point clients at `/mcp` and follow redirects, or use `/mcp/` directly.)
-
-#### Step 1 — one instance per profile
-
-A **profile** is one shared data config file + a per-process env block (namespace/tags/token) + its own port. Run **one instance per profile**. Every instance loads the *same* data config file (graph path, vector `db_path`, embedder); what differs is the per-process env block — and that env block **is** the profile.
-
-```bash
-# "journal-assistant" — reads your diary and reflects back, but can never edit it.
-# Whole-instance read-only: no write tools at all.
-LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
-LOGSEQ_INCLUDE_NAMESPACES=Journal \
-MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
-mcp-logseq --transport http --port 12320 --read-only
-
-# "work" — full read/write within Work/, and explicitly no diary access.
-LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
-LOGSEQ_INCLUDE_NAMESPACES=Work \
-LOGSEQ_EXCLUDE_NAMESPACES=Journal \
-MCP_HTTP_AUTH_TOKEN=$WORK_TOKEN \
-mcp-logseq --transport http --port 12321
-
-# "personal" — broad read/write, but credentials stay invisible.
-LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
-LOGSEQ_EXCLUDE_TAGS=keys,secret \
-MCP_HTTP_AUTH_TOKEN=$PERSONAL_TOKEN \
-mcp-logseq --transport http --port 12322
-```
-
-The `LOGSEQ_CONFIG_FILE` is identical across all three instances; the per-process env block is what makes each one a distinct profile. Because each instance is its own process, one profile's env (token, namespace scope, excluded tags) is never loaded by another — isolation is the process boundary.
-
-#### Step 2 — the separate sync writer
-
-The vector DB has exactly **one** writer: a dedicated `logseq-sync` process deployed **outside** every MCP instance. It indexes the whole graph under a single global policy — `vector.exclude_tags` should hold only the secrets/never-store tags. Per-profile differentiation is purely *query-time* on the reader instances above; the index itself is shared.
-
-```bash
-# Continuous writer (launchd / systemd unit), owns the DB — same shared data file:
-LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --watch
-
-# Or scheduled one-shot (cron / launchd StartInterval):
-LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --once
-```
-
-`logseq-sync` reads **no ACL env** — only the `vector` block and graph path from the data file. (`--rebuild` drops and re-indexes from scratch; `--status` prints a staleness report.) The reader profiles open the same `db_path` read-only and never run sync: the MCP `sync_vector_db` tool is inert and simply points operators at this external writer.
-
-#### Step 3 — encrypt anything past loopback
-
-> **The bearer token and all content travel as plaintext over plain HTTP.** Anything reachable beyond loopback must be encrypted — either native TLS on the instance, or a TLS-terminating reverse proxy in front of a loopback-bound instance.
-
-To enforce this, the server **refuses to bind a non-loopback host over plain HTTP**. A host outside the loopback set (`127.0.0.1`, `localhost`, `::1`) requires one of:
-
-- **Native TLS** — pass `--tls-cert` and `--tls-key`. TLS is allowed on any host.
-- **A TLS-terminating reverse proxy** in front, with the instance bound to a loopback address (recommended — see below).
-- **`--insecure`** — consciously accept an unencrypted non-loopback bind. Only sane on a trusted network or already behind a TLS proxy.
-
-Loopback binds over plain HTTP need no opt-in; that remains the default.
-
-**Native TLS** wraps the instance directly in HTTPS (uvicorn's `ssl_certfile`/`ssl_keyfile`):
-
-```bash
-mcp-logseq --transport http --port 12320 \
-  --tls-cert /path/cert.pem --tls-key /path/key.pem
-```
-
-`--tls-cert` and `--tls-key` must be supplied **together** (both or neither, else the server exits), and both files **must exist** at startup. For the certificate itself: use [`mkcert`](https://github.com/FiloSottile/mkcert) or a self-signed cert for host-internal/dev use, or [Let's Encrypt](https://letsencrypt.org/) when the instance is reachable on a public DNS name. The per-profile env blocks from [Step 1](#step-1--one-instance-per-profile) are unchanged — TLS just changes the wire, not the profile.
-
-**Recommended production path — reverse proxy with automatic HTTPS.** Bind the instance to loopback and let a proxy such as [Caddy](https://caddyserver.com/) terminate TLS (it obtains and renews Let's Encrypt certificates automatically):
-
-```caddyfile
-# Caddyfile — automatic HTTPS in front of a loopback-bound instance
-logseq.example.com {
-    reverse_proxy 127.0.0.1:12320
-}
-```
-
-With the instance running as `mcp-logseq --transport http --port 12320` (loopback default, no `--insecure` needed), clients reach it over HTTPS at `logseq.example.com` while the unencrypted hop stays inside the host.
 
 ### Alternative Setup Methods
 

--- a/docs/SERVING.md
+++ b/docs/SERVING.md
@@ -1,0 +1,106 @@
+# Serving mcp-logseq over HTTP
+
+> **Advanced deployment guide.** For local single-user use you need none of this — the default **stdio** transport (covered in the [README](../README.md)) is spawned by your client as a subprocess. This guide covers running `mcp-logseq` as a networked **HTTP** service for sandboxed or remote clients: the server-side security model, the per-profile multi-instance pattern, the separate vector sync writer, and TLS.
+
+For the namespace/tag access-control env vars themselves (`LOGSEQ_INCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_NAMESPACES`, `LOGSEQ_EXCLUDE_TAGS`), see [Privacy & Access Control](../README.md#-privacy--access-control) in the README — they apply to every transport.
+
+## 🔒 Security model
+
+When serving multiple clients over HTTP, isolation rests on a few guarantees:
+
+- **ACL is enforced server-side, before any bytes leave the process.** Blocked pages are filtered out of listings/search and denied on direct read/write — a client never receives content it isn't scoped to. Block-level results from `search` and `query` are resolved back to their owning page and filtered too.
+- **Bearer auth.** Every HTTP request must carry `Authorization: Bearer <MCP_HTTP_AUTH_TOKEN>`; unauthenticated requests are rejected.
+- **Loopback binding.** Default `--host 127.0.0.1` (loopback). Non-loopback binds are refused over plain HTTP — they require TLS (`--tls-cert`/`--tls-key`) or an explicit `--insecure` (see [Step 3](#step-3--encrypt-anything-past-loopback)).
+- **Process-boundary isolation.** Multi-instance means one profile's config (token, namespace scope, excluded tags) is never loaded by another process.
+- **Read tools** enforce namespace allow/deny *or* tag exclusion. **Write tools** enforce namespace gating plus tag-on-write checks against the existing page, so a write can't slip into a blocked namespace or onto an excluded page.
+- **Tag matching is case-SENSITIVE; namespace matching is case-INSENSITIVE.** Namespaces match regardless of case (`work` matches `Work/Projects`), but `LOGSEQ_EXCLUDE_TAGS` / `vector.exclude_tags` must match the **stored** tag casing exactly. Logseq typically stores tags lowercased, so `LOGSEQ_EXCLUDE_TAGS=Secret` will **not** exclude a page tagged `secret`. Match the casing as stored, or a page you meant to hide stays visible.
+
+## 🌐 Serving over HTTP (multi-profile)
+
+By default the server speaks **stdio** — the local client spawns it as a subprocess. For serving sandboxed or remote clients (each one only allowed to see a slice of your graph), the server can also run as a long-lived **HTTP** process:
+
+```bash
+mcp-logseq --transport http --host 127.0.0.1 --port 12320
+```
+
+- `--transport {stdio,http}` — default `stdio`.
+- `--host` — default `127.0.0.1` (loopback). Binding a non-loopback host over plain HTTP is **refused** unless you supply TLS or pass `--insecure`; see [Step 3 — encrypt anything past loopback](#step-3--encrypt-anything-past-loopback).
+- `--port` — default `12320`.
+- `--read-only` — unregisters the 8 write tools (see [Security model](#-security-model)); read tools and the vector tools remain.
+- `--tls-cert` / `--tls-key` — serve native HTTPS; see [Step 3](#step-3--encrypt-anything-past-loopback).
+
+HTTP mode **requires** `MCP_HTTP_AUTH_TOKEN`; the server exits if it is missing. Clients authenticate with `Authorization: Bearer <token>` and target the MCP endpoint at **`/mcp`**. (A bare POST to `/mcp` issues a `307` redirect to `/mcp/`; point clients at `/mcp` and follow redirects, or use `/mcp/` directly.)
+
+### Step 1 — one instance per profile
+
+A **profile** is one shared data config file + a per-process env block (namespace/tags/token) + its own port. Run **one instance per profile**. Every instance loads the *same* data config file (graph path, vector `db_path`, embedder); what differs is the per-process env block — and that env block **is** the profile.
+
+```bash
+# "journal-assistant" — reads your diary and reflects back, but can never edit it.
+# Whole-instance read-only: no write tools at all.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Journal \
+MCP_HTTP_AUTH_TOKEN=$JOURNAL_TOKEN \
+mcp-logseq --transport http --port 12320 --read-only
+
+# "work" — full read/write within Work/, and explicitly no diary access.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_INCLUDE_NAMESPACES=Work \
+LOGSEQ_EXCLUDE_NAMESPACES=Journal \
+MCP_HTTP_AUTH_TOKEN=$WORK_TOKEN \
+mcp-logseq --transport http --port 12321
+
+# "personal" — broad read/write, but credentials stay invisible.
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json \
+LOGSEQ_EXCLUDE_TAGS=keys,secret \
+MCP_HTTP_AUTH_TOKEN=$PERSONAL_TOKEN \
+mcp-logseq --transport http --port 12322
+```
+
+The `LOGSEQ_CONFIG_FILE` is identical across all three instances; the per-process env block is what makes each one a distinct profile. Because each instance is its own process, one profile's env (token, namespace scope, excluded tags) is never loaded by another — isolation is the process boundary.
+
+### Step 2 — the separate sync writer
+
+The vector DB has exactly **one** writer: a dedicated `logseq-sync` process deployed **outside** every MCP instance. It indexes the whole graph under a single global policy — `vector.exclude_tags` should hold only the secrets/never-store tags. Per-profile differentiation is purely *query-time* on the reader instances above; the index itself is shared.
+
+```bash
+# Continuous writer (launchd / systemd unit), owns the DB — same shared data file:
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --watch
+
+# Or scheduled one-shot (cron / launchd StartInterval):
+LOGSEQ_CONFIG_FILE=~/.logseq/data.json logseq-sync --once
+```
+
+`logseq-sync` reads **no ACL env** — only the `vector` block and graph path from the data file. (`--rebuild` drops and re-indexes from scratch; `--status` prints a staleness report.) The reader profiles open the same `db_path` read-only and never run sync: the MCP `sync_vector_db` tool is inert and simply points operators at this external writer.
+
+### Step 3 — encrypt anything past loopback
+
+> **The bearer token and all content travel as plaintext over plain HTTP.** Anything reachable beyond loopback must be encrypted — either native TLS on the instance, or a TLS-terminating reverse proxy in front of a loopback-bound instance.
+
+To enforce this, the server **refuses to bind a non-loopback host over plain HTTP**. A host outside the loopback set (`127.0.0.1`, `localhost`, `::1`) requires one of:
+
+- **Native TLS** — pass `--tls-cert` and `--tls-key`. TLS is allowed on any host.
+- **A TLS-terminating reverse proxy** in front, with the instance bound to a loopback address (recommended — see below).
+- **`--insecure`** — consciously accept an unencrypted non-loopback bind. Only sane on a trusted network or already behind a TLS proxy.
+
+Loopback binds over plain HTTP need no opt-in; that remains the default.
+
+**Native TLS** wraps the instance directly in HTTPS (uvicorn's `ssl_certfile`/`ssl_keyfile`):
+
+```bash
+mcp-logseq --transport http --port 12320 \
+  --tls-cert /path/cert.pem --tls-key /path/key.pem
+```
+
+`--tls-cert` and `--tls-key` must be supplied **together** (both or neither, else the server exits), and both files **must exist** at startup. For the certificate itself: use [`mkcert`](https://github.com/FiloSottile/mkcert) or a self-signed cert for host-internal/dev use, or [Let's Encrypt](https://letsencrypt.org/) when the instance is reachable on a public DNS name. The per-profile env blocks from [Step 1](#step-1--one-instance-per-profile) are unchanged — TLS just changes the wire, not the profile.
+
+**Recommended production path — reverse proxy with automatic HTTPS.** Bind the instance to loopback and let a proxy such as [Caddy](https://caddyserver.com/) terminate TLS (it obtains and renews Let's Encrypt certificates automatically):
+
+```caddyfile
+# Caddyfile — automatic HTTPS in front of a loopback-bound instance
+logseq.example.com {
+    reverse_proxy 127.0.0.1:12320
+}
+```
+
+With the instance running as `mcp-logseq --transport http --port 12320` (loopback default, no `--insecure` needed), clients reach it over HTTPS at `logseq.example.com` while the unencrypted hop stays inside the host.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-logseq"
-version = "1.7.0"
+version = "1.8.0"
 description = "MCP server to work with LogSeq via the local HTTP server"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release **v1.8.0**.

## Included
- **Version bump** 1.7.0 → 1.8.0
- **CHANGELOG** 1.8.0 entry covering the HTTP/SSE transport + secure multi-profile serving (#69) and native TLS + bind guardrail (#71)
- **Docs split**: the advanced HTTP-serving / security-model / multi-profile / TLS content moved to **docs/SERVING.md** (README dropped from 461 → 371 lines, with a pointer)
- **README fix**: nested code-fence in the Smart Markdown Parsing section was breaking rendering of the `**Result:**` list — fixed by switching the outer fence to four backticks
- **Docs accuracy**: corrected the now-stale block-level ACL "known limitation" (block results from `search`/`query` are resolved to their owning page and filtered as of #69)

No code changes — features already merged via #69 and #71. Full suite: 569 passing.

## After merge
Tag `v1.8.0` and cut the GitHub release.
