### PR TITLE
feat(vector): add OpenAI-compatible embedding providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Transform your LogSeq knowledge base into an AI-powered workspace! This MCP serv
 - **Preserve Your Workflow**: No need to export or copy content manually
 - **Intelligent Organization**: AI-powered page creation, linking, and search
 - **Enhanced Productivity**: Automate repetitive knowledge work
-- **Semantic Vector Search** *(optional)*: Find notes by meaning using local Ollama embeddings — no data leaves your machine
+- **Semantic Vector Search** *(optional)*: Find notes by meaning using local Ollama or hosted OpenAI-compatible embeddings
 - **DB-mode Support** *(opt-in)*: Read and write class properties on Logseq DB-mode graphs
 
 ---
@@ -98,9 +98,9 @@ Add to your config file (`Settings → Developer → Edit Config`):
 
 ## 🔬 Vector Search (Optional)
 
-Semantic search over your Logseq graph using local AI embeddings — find notes by meaning, not just keywords. Searches across all your pages using vector similarity and full-text search combined, with cross-language support.
+Semantic search over your Logseq graph using configurable embeddings — find notes by meaning, not just keywords. Searches across all your pages using vector similarity and full-text search combined, with cross-language support.
 
-Powered by [Ollama](https://ollama.com) (local embeddings) and [LanceDB](https://lancedb.com) (embedded vector DB). No data leaves your machine.
+Use [Ollama](https://ollama.com) for fully local embeddings, OpenAI, or another OpenAI-compatible embeddings endpoint. [LanceDB](https://lancedb.com) remains local in every configuration. Hosted providers receive the note text being embedded.
 
 → **[Full setup guide: VECTOR_SEARCH.md](VECTOR_SEARCH.md)**
 

--- a/VECTOR_SEARCH.md
+++ b/VECTOR_SEARCH.md
@@ -1,6 +1,6 @@
 # Vector Search Setup Guide
 
-Semantic search over your Logseq graph using local AI embeddings. Find notes by meaning rather than exact keywords — works across languages and concepts.
+Semantic search over your Logseq graph using local or hosted AI embeddings. Find notes by meaning rather than exact keywords — works across languages and concepts.
 
 ## Architecture
 
@@ -9,18 +9,20 @@ Semantic search over your Logseq graph using local AI embeddings. Find notes by 
 ## How It Works
 
 1. Your `.md` files are read directly from disk (not via the Logseq API)
-2. Each page is chunked into blocks and embedded using a local Ollama model
+2. Each page is chunked into blocks and embedded using the configured provider
 3. Embeddings are stored in a [LanceDB](https://lancedb.com) database on your machine
 4. `vector_search` queries combine vector similarity + full-text search with RRF reranking
 5. When your notes change, an incremental sync re-embeds only the changed files
 
-No data leaves your machine. Ollama and LanceDB both run locally.
+LanceDB always runs locally. With Ollama, note text also stays local. OpenAI and
+other hosted providers receive the chunks and search queries they embed; review
+the provider's data-handling policy before enabling a hosted service.
 
 ---
 
 ## Prerequisites
 
-### 1. Ollama
+### 1. Choose an embedding provider
 
 Install Ollama from [ollama.com](https://ollama.com) and pull an embedding model:
 
@@ -35,6 +37,11 @@ Confirm it's running:
 ```bash
 curl http://localhost:11434/api/embed -d '{"model":"qwen3-embedding:8b","input":["test"]}'
 ```
+
+For a hosted provider, obtain an API key and the provider's embedding model
+name. OpenAI works with its default base URL. Other services must expose an
+OpenAI-compatible `POST /embeddings` endpoint and provide the base URL ending in
+`/v1` (or the equivalent API root).
 
 ### 2. Vector extras
 
@@ -82,6 +89,43 @@ mkdir -p ~/.logseq-vector
 }
 ```
 
+The example above uses Ollama. To use OpenAI instead, replace the `embedder`
+block with:
+
+```json
+"embedder": {
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "api_key": "replace-with-your-api-key"
+}
+```
+
+OpenAI defaults to `https://api.openai.com/v1`. The optional `dimensions`
+field requests a specific output size on models that support it:
+
+```json
+"embedder": {
+  "provider": "openai",
+  "model": "text-embedding-3-small",
+  "api_key": "replace-with-your-api-key",
+  "dimensions": 512
+}
+```
+
+For another service implementing the OpenAI embeddings contract:
+
+```json
+"embedder": {
+  "provider": "openai-compatible",
+  "model": "provider-model-name",
+  "base_url": "https://embeddings.example.com/v1",
+  "api_key": "replace-if-required"
+}
+```
+
+`api_key` is optional for `openai-compatible`, which allows an unauthenticated
+local service. It is required for `openai`.
+
 This keeps everything in one place:
 
 ```text
@@ -96,12 +140,19 @@ This keeps everything in one place:
 | `exclude_tags` | no | **Project-level privacy filter** — pages with these tags are hidden from all tools (list, search, query, get content) *and* excluded from the vector index. Use this for pages with sensitive content (e.g. API keys, personal notes). |
 | `vector.enabled` | ✅ | Must be `true` to activate vector tools |
 | `vector.db_path` | ✅ | Where to store the vector DB — keep it local, not in iCloud |
-| `vector.embedder.model` | ✅ | Ollama model name — must match what you pulled |
+| `vector.embedder.provider` | no | `ollama` (default), `openai`, or `openai-compatible` |
+| `vector.embedder.model` | provider-dependent | Defaults to `nomic-embed-text` for Ollama and `text-embedding-3-small` for OpenAI; required for `openai-compatible` |
+| `vector.embedder.base_url` | provider-dependent | Defaults to local Ollama or OpenAI's API root; required for `openai-compatible` |
+| `vector.embedder.api_key` | provider-dependent | Required for OpenAI; optional bearer token for `openai-compatible`; ignored by Ollama |
+| `vector.embedder.dimensions` | no | Positive integer requested from an OpenAI-compatible endpoint; changing it requires a rebuild |
 | `vector.include_journals` | no | Index journal pages (default: `true`) |
 | `vector.exclude_tags` | no | Additional tags to skip from the vector index only (additive with top-level `exclude_tags`). Use for noise filtering — e.g. large reference dumps that pollute semantic search but are fine to read directly. (default: `[]`) |
 | `vector.min_chunk_length` | no | Minimum characters per chunk (default: `50`) |
 
 **Important:** keep `db_path` outside your iCloud-synced Logseq folder. The DB is a generated binary artifact — syncing it to iCloud wastes bandwidth and can cause corruption.
+
+If `config.json` contains an API key, do not commit or share it. Restrict it to
+your user account, for example with `chmod 600 ~/.logseq-vector/config.json`.
 
 ---
 
@@ -205,7 +256,8 @@ Triggers an incremental sync — only changed files are re-embedded. Claude call
 | --- | --- | --- | --- |
 | `rebuild` | boolean | `false` | Drop and re-index everything from scratch |
 
-Ask Claude `"rebuild the search index"` if you change your embedding model.
+Run `logseq-sync --rebuild` if you change the embedding provider, model, or
+configured dimensions.
 
 ### `vector_db_status`
 
@@ -255,19 +307,33 @@ For continuous sync without the MCP auto-trigger, `--watch` is the recommended a
 - Confirm the model is downloaded: `ollama pull qwen3-embedding:8b`
 - Check `base_url` in config matches your Ollama address
 
+### Hosted embedding request fails
+
+- Confirm `api_key`, `model`, and `base_url` belong to the same provider
+- For `openai-compatible`, set `base_url` to the API root immediately before
+  `/embeddings`; for example, `https://embeddings.example.com/v1`
+- A `401` or `403` usually means the API key is missing, invalid, or lacks
+  access to the selected model
+- Check provider rate limits if a sync succeeds for some batches and skips
+  others
+
 ### Embedder mismatch error on sync
 
-If you change the `model` in your config after an initial sync:
+If you change the provider, model, or configured dimensions after an initial
+sync:
 
 ```bash
 logseq-sync --rebuild
 ```
 
-This drops the existing DB and re-indexes from scratch with the new model.
+This drops the existing DB and re-indexes from scratch with the new embedding
+space. Rotating only `api_key` does not require a rebuild.
 
 ### Slow first sync
 
-Large graphs with `qwen3-embedding:8b` take ~20s per batch of 32 chunks. A graph with 500 pages typically takes 15–30 minutes. Subsequent incremental syncs are much faster — only changed files are re-embedded.
+First-sync time depends on graph size, model size, provider latency, and rate
+limits. Subsequent incremental syncs are much faster because only changed files
+are re-embedded.
 
 ### Pages missing from results
 

--- a/docs/superpowers/plans/2026-07-10-pluggable-embedding-providers.md
+++ b/docs/superpowers/plans/2026-07-10-pluggable-embedding-providers.md
@@ -1,0 +1,128 @@
+# Pluggable Embedding Providers Implementation Plan
+
+> **Goal:** Add OpenAI and OpenAI-compatible embedding providers while
+> preserving existing Ollama behavior and vector-index safety.
+
+Design: [Pluggable Embedding Providers](../specs/2026-07-10-pluggable-embedding-providers-design.md)
+
+## Task 1: Extend and validate configuration
+
+**Files:**
+
+- Modify: `src/mcp_logseq/config.py`
+- Test: `tests/unit/vector/test_config.py`
+
+- [x] Add failing tests for OpenAI, OpenAI-compatible, provider-specific
+  defaults, `api_key`, `dimensions`, and required fields.
+- [x] Add optional `api_key` and `dimensions` to `EmbedderConfig`.
+- [x] Replace the Ollama-only rejection with provider-specific parsing and
+  validation while preserving the loader's never-raise contract.
+- [x] Run the affected config tests.
+
+## Task 2: Implement hosted adapter
+
+**Files:**
+
+- Modify: `src/mcp_logseq/vector/embedder.py`
+- Test: `tests/unit/vector/test_embedder.py`
+
+- [x] Add failing request/response, validation, error, key, and factory tests.
+- [x] Implement `OpenAICompatibleEmbedder` with optional bearer auth and
+  requested dimensions.
+- [x] Validate and reorder response vectors before exposing them to sync/search.
+- [x] Extend `create_embedder()` for `openai` and `openai-compatible`.
+- [x] Run the affected embedder tests.
+
+## Task 3: Remove Ollama-only assumptions
+
+**Files:**
+
+- Modify: `src/mcp_logseq/bin/logseq_sync.py`
+- Modify: `src/mcp_logseq/vector/sync.py`
+- Test: `tests/unit/vector/test_logseq_sync.py`
+
+- [x] Make connection and batching messages provider-neutral.
+- [x] Refuse sync and search when configured provider/model/dimensions do not
+  match the existing vector index.
+- [x] Add a CLI regression test for the selected provider in startup output.
+- [x] Run affected CLI and sync tests.
+
+## Task 4: Document configuration and migration behavior
+
+**Files:**
+
+- Modify: `VECTOR_SEARCH.md`
+- Modify: `README.md`
+
+- [x] Describe supported provider values and each provider's required fields.
+- [x] Add complete Ollama, OpenAI, and OpenAI-compatible examples.
+- [x] Document credential handling and the required rebuild after changing
+  provider, model, or dimensions.
+- [x] Remove wording that claims vector search is Ollama-only or always local.
+
+## Task 5: Validate the branch
+
+- [x] Run Pyright over every modified Python file with no errors.
+- [x] Keep the repository-wide Pyright baseline out of scope; scoped checking
+  was explicitly approved, and unrelated existing typing errors are unchanged.
+- [x] Run `uv build` with no errors.
+- [x] Run `uv run pytest tests/unit/` with no failures.
+- [x] Review the diff for credentials, unrelated changes, and compatibility.
+- [x] Prepare draft GitHub issue and pull-request descriptions without
+  publishing them yet.
+
+## GitHub Publication Drafts
+
+### Issue
+
+**Title:** `feat(vector): support OpenAI-compatible embedding providers`
+
+**Body:**
+
+The optional vector-search feature currently accepts only a local Ollama
+embedder. Users should be able to select a hosted OpenAI embedding model or any
+service implementing the OpenAI embeddings request/response contract.
+
+Proposed configuration extends the existing `vector.embedder` object with
+provider-specific `base_url`, `api_key`, and optional `dimensions` fields while
+preserving all current Ollama defaults. The implementation should keep the
+provider-neutral `Embedder` interface, avoid a new SDK dependency, validate
+hosted responses, and refuse searches or incremental syncs when the configured
+embedding space does not match the existing vector index.
+
+Acceptance criteria:
+
+- Existing Ollama configurations work without migration or re-indexing.
+- `provider: "openai"` uses the OpenAI embeddings API with a required API key.
+- `provider: "openai-compatible"` uses a configurable API root and optional
+  bearer token.
+- Hosted responses are ordered and validated before reaching LanceDB.
+- Provider, model, or dimension changes require `logseq-sync --rebuild`.
+- API keys are never logged or persisted in sync metadata.
+- Documentation explains hosted-provider data flow and credential handling.
+
+### Pull Request
+
+**Title:** `feat(vector): add OpenAI-compatible embedding providers`
+
+**Body:**
+
+## Summary
+
+- add `openai` and `openai-compatible` provider configuration alongside Ollama
+- add bearer authentication, optional output dimensions, and strict hosted
+  response validation without introducing a new runtime dependency
+- guard both sync and search against provider/model/dimension mismatches
+- make sync output provider-neutral and document local versus hosted data flow
+
+## Validation
+
+- modified-file Pyright: 0 errors
+- unit tests: 576 passed
+- package build: source distribution and wheel built successfully
+
+## Known repository baseline
+
+Repository-wide Pyright 1.1.411 currently reports 63 pre-existing errors outside
+the feature files. Those are not included in this feature diff and must be
+resolved or baselined before claiming a clean repository-wide lint gate.

--- a/docs/superpowers/specs/2026-07-10-pluggable-embedding-providers-design.md
+++ b/docs/superpowers/specs/2026-07-10-pluggable-embedding-providers-design.md
@@ -1,0 +1,172 @@
+# Pluggable Embedding Providers
+
+**Date:** 2026-07-10  
+**Status:** Approved by request; implementation follows this design
+
+## Goal
+
+Allow vector search to use hosted embedding services instead of requiring a
+local Ollama process. Preserve every existing Ollama configuration and keep the
+provider boundary small enough that future, non-compatible APIs can be added as
+adapters rather than changing the sync and search code.
+
+The first increment supports three provider values:
+
+- `ollama` — the existing local `POST /api/embed` integration.
+- `openai` — OpenAI's hosted `POST /v1/embeddings` API.
+- `openai-compatible` — any service exposing the same request and response
+  shape, with a configurable base URL and optional bearer token.
+
+## Decisions
+
+1. **Keep the existing `Embedder` interface.** Sync and query code already
+   depend only on `embed()`, `dimensions`, and `key`; provider selection remains
+   in `create_embedder()`.
+2. **Use direct HTTP through the existing `requests` dependency.** Adding an SDK
+   for one small endpoint would increase install size and couple the project to
+   a vendor-specific client without improving the abstraction.
+3. **Add provider credentials to the existing JSON config.** `api_key` is read
+   only from `vector.embedder`; it is never logged, included in exceptions, or
+   stored in vector sync metadata.
+4. **Support an optional requested dimension.** `dimensions` is sent by the
+   OpenAI-compatible adapter when configured and becomes part of the embedder
+   identity because changing vector size requires a full rebuild.
+5. **Validate hosted responses at the boundary.** The adapter sorts results by
+   response `index`, then checks result count, index uniqueness, numeric vectors,
+   non-empty vectors, and consistent dimensions before returning them.
+6. **Preserve Ollama defaults and identity.** Existing configs continue to use
+   `nomic-embed-text`, `http://localhost:11434`, and keys such as
+   `ollama/nomic-embed-text`.
+7. **Treat provider/model/dimensions changes as index changes.** Sync and search
+   both compare the configured embedder identity and dimensions with index
+   metadata and require `logseq-sync --rebuild` on a mismatch. API key rotation
+   and base-URL proxy changes do not change the key.
+
+## Configuration
+
+### Existing Ollama configuration
+
+No migration is required:
+
+```json
+{
+  "vector": {
+    "enabled": true,
+    "embedder": {
+      "provider": "ollama",
+      "model": "nomic-embed-text",
+      "base_url": "http://localhost:11434"
+    }
+  }
+}
+```
+
+### OpenAI
+
+```json
+{
+  "vector": {
+    "enabled": true,
+    "embedder": {
+      "provider": "openai",
+      "model": "text-embedding-3-small",
+      "api_key": "replace-with-your-api-key",
+      "dimensions": 1536
+    }
+  }
+}
+```
+
+`base_url` defaults to `https://api.openai.com/v1`. `model` defaults to
+`text-embedding-3-small`. `api_key` is required.
+
+### OpenAI-compatible service
+
+```json
+{
+  "vector": {
+    "enabled": true,
+    "embedder": {
+      "provider": "openai-compatible",
+      "model": "provider-model-name",
+      "base_url": "https://embeddings.example.com/v1",
+      "api_key": "replace-if-required"
+    }
+  }
+}
+```
+
+Both `model` and `base_url` are required. `api_key` is optional so the adapter
+also works with unauthenticated local OpenAI-compatible servers.
+
+| Field | Ollama | OpenAI | OpenAI-compatible |
+| --- | --- | --- | --- |
+| `provider` | `ollama` | `openai` | `openai-compatible` |
+| `model` | optional; defaults to `nomic-embed-text` | optional; defaults to `text-embedding-3-small` | required |
+| `base_url` | optional; defaults to local Ollama | optional; defaults to OpenAI | required |
+| `api_key` | ignored | required | optional |
+| `dimensions` | ignored | optional | optional |
+
+Because `config.json` may now contain a credential, documentation must tell
+users not to commit or share it and to restrict its filesystem permissions.
+
+## Request and Response Contract
+
+The hosted adapter sends:
+
+```http
+POST {base_url}/embeddings
+Authorization: Bearer {api_key}
+Content-Type: application/json
+
+{"model": "...", "input": ["..."], "encoding_format": "float"}
+```
+
+`dimensions` is included only when configured. A missing API key omits the
+`Authorization` header for `openai-compatible`; official `openai` configuration
+rejects a missing key before making a request.
+
+The adapter reads `data[].embedding` and restores input order with
+`data[].index`. This follows the current OpenAI embeddings API contract:
+<https://developers.openai.com/api/reference/resources/embeddings/methods/create>.
+
+## Error Model
+
+- Connection, timeout, and HTTP failures become provider-specific
+  `RuntimeError` messages consistent with the existing Ollama adapter.
+- Invalid JSON or malformed embedding results fail the whole batch. The sync
+  engine retains its existing behavior of logging and skipping a failed batch.
+- Error messages include provider and endpoint context but never request
+  headers, payload credentials, or `api_key`.
+- A configured dimension that differs from the returned vector size is a hard
+  error.
+
+## Backward Compatibility
+
+- `provider` still defaults to `ollama`.
+- Existing Ollama model and base-URL defaults are unchanged.
+- No new runtime dependency is added.
+- Existing vector databases keep the same Ollama embedder key and do not require
+  rebuilding.
+- Switching provider, model, or configured dimensions triggers the existing
+  rebuild-required error before incremental sync modifies the database.
+
+## Test Strategy
+
+- Config tests for provider defaults, hosted fields, required fields, unknown
+  providers, and Ollama regression behavior.
+- Adapter tests for URL, bearer auth, payload, ordering, dimension detection,
+  configured dimensions, empty input, missing key, network/HTTP errors, empty or
+  malformed responses, and provider factory dispatch.
+- CLI test to ensure startup messaging is provider-neutral.
+- Existing sync mismatch tests continue to cover rebuild enforcement.
+- Full `pyright`, package build, and unit test suite before handoff.
+
+## Out of Scope
+
+- Provider APIs that do not implement the OpenAI embeddings contract, such as
+  bespoke Cohere or cloud-platform deployment paths. They can be added later as
+  new `Embedder` implementations.
+- Retry/backoff and rate-limit scheduling.
+- Environment-variable interpolation inside JSON values.
+- Automatic migration or rebuilding of an existing vector database.

--- a/src/mcp_logseq/bin/logseq_sync.py
+++ b/src/mcp_logseq/bin/logseq_sync.py
@@ -89,7 +89,10 @@ def _run_sync(config, rebuild: bool = False) -> None:
 
     lock_file = _acquire_sync_lock(config.db_path)
     try:
-        print(f"Connecting to Ollama ({config.embedder.model})...")
+        print(
+            f"Connecting to embedding provider {config.embedder.provider} "
+            f"({config.embedder.model})..."
+        )
         try:
             embedder = create_embedder(config.embedder)
             dimensions = embedder.dimensions

--- a/src/mcp_logseq/config.py
+++ b/src/mcp_logseq/config.py
@@ -24,6 +24,10 @@ Example config.json:
     "watch_debounce_ms": 5000
   }
 }
+
+Supported embedder providers are "ollama", "openai", and
+"openai-compatible". Hosted providers may also use "api_key" and "dimensions"
+inside the embedder block.
 """
 
 from __future__ import annotations
@@ -40,7 +44,9 @@ logger = logging.getLogger("mcp-logseq.config")
 class EmbedderConfig:
     provider: str
     model: str
-    base_url: str = "http://localhost:11434"
+    base_url: str | None = None
+    api_key: str | None = None
+    dimensions: int | None = None
 
 
 @dataclass
@@ -78,7 +84,7 @@ def load_vector_config() -> VectorConfig | None:
         return None
 
     vector_raw = raw.get("vector")
-    if not vector_raw or not vector_raw.get("enabled"):
+    if not isinstance(vector_raw, dict) or not vector_raw.get("enabled"):
         return None
 
     graph_path = raw.get("logseq_graph_path", "")
@@ -87,15 +93,61 @@ def load_vector_config() -> VectorConfig | None:
         return None
 
     embedder_raw = vector_raw.get("embedder", {})
-    provider = embedder_raw.get("provider", "ollama")
-    if provider != "ollama":
-        logger.warning(f"Unsupported embedder provider '{provider}' — only 'ollama' is supported")
+    if not isinstance(embedder_raw, dict):
+        logger.warning("Vector 'embedder' configuration must be an object")
+        return None
+    provider = str(embedder_raw.get("provider", "ollama")).strip().lower()
+    supported_providers = {"ollama", "openai", "openai-compatible"}
+    if provider not in supported_providers:
+        supported = ", ".join(sorted(supported_providers))
+        logger.warning(
+            f"Unsupported embedder provider '{provider}' — supported providers: {supported}"
+        )
+        return None
+
+    default_models = {
+        "ollama": "nomic-embed-text",
+        "openai": "text-embedding-3-small",
+        "openai-compatible": "",
+    }
+    default_base_urls = {
+        "ollama": "http://localhost:11434",
+        "openai": "https://api.openai.com/v1",
+        "openai-compatible": "",
+    }
+    model_raw = embedder_raw.get("model")
+    base_url_raw = embedder_raw.get("base_url")
+    model = str(
+        default_models[provider] if model_raw is None else model_raw
+    ).strip()
+    base_url = str(
+        default_base_urls[provider] if base_url_raw is None else base_url_raw
+    ).strip()
+    api_key_raw = embedder_raw.get("api_key")
+    api_key = str(api_key_raw).strip() if api_key_raw is not None else None
+    dimensions = embedder_raw.get("dimensions")
+
+    if not model:
+        logger.warning(f"Embedder provider '{provider}' requires 'model'")
+        return None
+    if not base_url:
+        logger.warning(f"Embedder provider '{provider}' requires 'base_url'")
+        return None
+    if provider == "openai" and not api_key:
+        logger.warning("Embedder provider 'openai' requires 'api_key'")
+        return None
+    if dimensions is not None and (
+        isinstance(dimensions, bool) or not isinstance(dimensions, int) or dimensions <= 0
+    ):
+        logger.warning("Embedder 'dimensions' must be a positive integer")
         return None
 
     embedder = EmbedderConfig(
         provider=provider,
-        model=embedder_raw.get("model", "nomic-embed-text"),
-        base_url=embedder_raw.get("base_url", "http://localhost:11434"),
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        dimensions=dimensions,
     )
 
     db_path = os.path.expanduser(vector_raw.get("db_path", "~/.logseq-vector"))

--- a/src/mcp_logseq/vector/embedder.py
+++ b/src/mcp_logseq/vector/embedder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from typing import Any
 
 import requests
 
@@ -79,9 +80,183 @@ class OllamaEmbedder(Embedder):
         return f"ollama/{self._model}"
 
 
+class OpenAICompatibleEmbedder(Embedder):
+    """Embed through an OpenAI-compatible ``POST /embeddings`` endpoint."""
+
+    def __init__(
+        self,
+        provider: str,
+        model: str,
+        base_url: str,
+        api_key: str | None = None,
+        dimensions: int | None = None,
+    ) -> None:
+        self._provider = provider
+        self._model = model
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._requested_dimensions = dimensions
+        self._dimensions = dimensions
+
+    @property
+    def _display_name(self) -> str:
+        return "OpenAI" if self._provider == "openai" else "OpenAI-compatible"
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "input": texts,
+            "encoding_format": "float",
+        }
+        if self._requested_dimensions is not None:
+            payload["dimensions"] = self._requested_dimensions
+
+        headers = {}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            response = requests.post(
+                f"{self._base_url}/embeddings",
+                json=payload,
+                headers=headers,
+                timeout=120,
+            )
+            response.raise_for_status()
+        except requests.ConnectionError:
+            raise RuntimeError(
+                f"Cannot connect to {self._display_name} embedding API at "
+                f"{self._base_url}."
+            )
+        except requests.Timeout:
+            raise RuntimeError(
+                f"{self._display_name} embedding request timed out at {self._base_url}."
+            )
+        except requests.HTTPError as e:
+            raise RuntimeError(f"{self._display_name} embedding request failed: {e}")
+        except requests.RequestException as e:
+            raise RuntimeError(
+                f"{self._display_name} embedding request failed: {e}"
+            )
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise RuntimeError(
+                f"{self._display_name} embedding API returned invalid JSON"
+            ) from e
+
+        vectors = self._parse_vectors(data, len(texts))
+        detected_dimensions = len(vectors[0])
+        if (
+            self._requested_dimensions is not None
+            and detected_dimensions != self._requested_dimensions
+        ):
+            raise RuntimeError(
+                f"{self._display_name} embedder was configured for "
+                f"{self._requested_dimensions} dimensions but returned "
+                f"{detected_dimensions}"
+            )
+        self._dimensions = detected_dimensions
+        logger.debug(
+            f"OpenAICompatibleEmbedder dimensions detected: {self._dimensions}"
+        )
+        return vectors
+
+    def _parse_vectors(self, data: object, expected_count: int) -> list[list[float]]:
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                f"{self._display_name} embedding API returned an invalid response"
+            )
+        items = data.get("data")
+        if not isinstance(items, list):
+            raise RuntimeError(
+                f"{self._display_name} embedding API returned an invalid response"
+            )
+        if len(items) != expected_count:
+            raise RuntimeError(
+                f"{self._display_name} returned {len(items)} embeddings for "
+                f"{expected_count} texts"
+            )
+
+        indexed_vectors: list[tuple[int, list[float]]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                raise RuntimeError(
+                    f"{self._display_name} response item is missing a numeric embedding"
+                )
+            index = item.get("index")
+            vector = item.get("embedding")
+            if (
+                isinstance(index, bool)
+                or not isinstance(index, int)
+                or not isinstance(vector, list)
+                or not vector
+                or any(
+                    isinstance(value, bool) or not isinstance(value, (int, float))
+                    for value in vector
+                )
+            ):
+                raise RuntimeError(
+                    f"{self._display_name} response item is missing a numeric embedding"
+                )
+            indexed_vectors.append((index, [float(value) for value in vector]))
+
+        indexed_vectors.sort(key=lambda item: item[0])
+        if [item[0] for item in indexed_vectors] != list(range(expected_count)):
+            raise RuntimeError(
+                f"{self._display_name} response contains invalid embedding indices"
+            )
+
+        vectors = [item[1] for item in indexed_vectors]
+        dimensions = len(vectors[0])
+        if any(len(vector) != dimensions for vector in vectors):
+            raise RuntimeError(
+                f"{self._display_name} returned embeddings with inconsistent dimensions"
+            )
+        return vectors
+
+    @property
+    def dimensions(self) -> int:
+        if self._dimensions is None:
+            self.embed(["probe"])
+        return self._dimensions  # type: ignore[return-value]
+
+    @property
+    def key(self) -> str:
+        key = f"{self._provider}/{self._model}"
+        if self._requested_dimensions is not None:
+            key += f"/dimensions={self._requested_dimensions}"
+        return key
+
+
 def create_embedder(config: EmbedderConfig) -> Embedder:
     if config.provider == "ollama":
-        return OllamaEmbedder(model=config.model, base_url=config.base_url)
+        return OllamaEmbedder(
+            model=config.model,
+            base_url=config.base_url or "http://localhost:11434",
+        )
+    if config.provider in {"openai", "openai-compatible"}:
+        if config.provider == "openai" and not config.api_key:
+            raise ValueError("Embedder provider 'openai' requires api_key")
+        base_url = config.base_url
+        if not base_url and config.provider == "openai":
+            base_url = "https://api.openai.com/v1"
+        if not base_url:
+            raise ValueError(
+                f"Embedder provider '{config.provider}' requires base_url"
+            )
+        return OpenAICompatibleEmbedder(
+            provider=config.provider,
+            model=config.model,
+            base_url=base_url,
+            api_key=config.api_key,
+            dimensions=config.dimensions,
+        )
     raise ValueError(
-        f"Unsupported embedder provider: '{config.provider}'. Only 'ollama' is supported."
+        f"Unsupported embedder provider: '{config.provider}'. "
+        "Supported providers: ollama, openai, openai-compatible."
     )

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import logging
 import os
 import time
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Protocol, TypeVar
 
 from mcp.types import TextContent, Tool
 
@@ -37,6 +39,20 @@ logger = logging.getLogger("mcp-logseq.vector.index")
 _WEAK_MATCH_THRESHOLD = 0.80  # scores above this are likely tangential; AI should use judgment
 
 
+class _PageResult(Protocol):
+    @property
+    def page(self) -> str: ...
+
+
+class _TaggedResult(Protocol):
+    @property
+    def tags(self) -> list[str] | None: ...
+
+
+_PageResultT = TypeVar("_PageResultT", bound=_PageResult)
+_TaggedResultT = TypeVar("_TaggedResultT", bound=_TaggedResult)
+
+
 def _relevance_label(score: float) -> str:
     if score < 0.65:
         return "high relevance"
@@ -46,17 +62,17 @@ def _relevance_label(score: float) -> str:
 
 
 def _filter_results_by_namespace(
-    results: list[SearchResult], include: list[str], exclude: list[str]
-) -> list[SearchResult]:
+    results: Sequence[_PageResultT], include: list[str], exclude: list[str]
+) -> list[_PageResultT]:
     """Drop vector search results whose page is blocked by namespace rules."""
     if not include and not exclude:
-        return results
+        return list(results)
     return [r for r in results if not _is_namespace_blocked(r.page, include, exclude)]
 
 
 def _filter_results_by_tags(
-    results: list[SearchResult], exclude_tags: list[str]
-) -> list[SearchResult]:
+    results: Sequence[_TaggedResultT], exclude_tags: list[str]
+) -> list[_TaggedResultT]:
     """Drop vector search results whose page carries an excluded tag.
 
     Mirrors the namespace filter: on a shared DB this prevents tag-blocked
@@ -64,7 +80,7 @@ def _filter_results_by_tags(
     Tag data is already on each result, so no API call is needed.
     """
     if not exclude_tags:
-        return results
+        return list(results)
     return [r for r in results if not any(t in exclude_tags for t in (r.tags or []))]
 
 
@@ -203,7 +219,19 @@ class VectorSearchToolHandler(ToolHandler):
             logger.debug(f"vector_search: embedding start (embedder={meta.embedder_key})")
             _t_emb = time.perf_counter()
             embedder = create_embedder(self._config.embedder)
+            if embedder.key != meta.embedder_key:
+                raise RuntimeError(
+                    f"Configured embedder '{embedder.key}' does not match vector DB "
+                    f"embedder '{meta.embedder_key}'. Run logseq-sync --rebuild to "
+                    f"re-index from scratch."
+                )
             query_vector = embedder.embed([query])[0]
+            if len(query_vector) != meta.dimensions:
+                raise RuntimeError(
+                    f"Configured embedder returned {len(query_vector)} dimensions but "
+                    f"the vector DB uses {meta.dimensions}. Run logseq-sync --rebuild "
+                    f"to re-index from scratch."
+                )
             logger.debug(f"vector_search: embedding done in {(time.perf_counter() - _t_emb) * 1000:.1f}ms")
         except RuntimeError as e:
             return [TextContent(type="text", text=str(e))]

--- a/src/mcp_logseq/vector/sync.py
+++ b/src/mcp_logseq/vector/sync.py
@@ -22,7 +22,7 @@ from mcp_logseq.vector.types import FileState, StalenessReport, SyncMeta, SyncRe
 
 logger = logging.getLogger("mcp-logseq.vector.sync")
 
-_EMBED_BATCH_SIZE = 16  # texts per Ollama call
+_EMBED_BATCH_SIZE = 16  # texts per embedding-provider call
 
 
 def _hash_file(path: Path) -> str:
@@ -94,7 +94,13 @@ class SyncEngine:
         if meta.embedder_key and meta.embedder_key != self._embedder.key:
             raise RuntimeError(
                 f"Embedder changed from '{meta.embedder_key}' to '{self._embedder.key}'. "
-                f"Run sync_vector_db with rebuild=true to re-index from scratch."
+                f"Run logseq-sync --rebuild to re-index from scratch."
+            )
+        if meta.dimensions and meta.dimensions != self._embedder.dimensions:
+            raise RuntimeError(
+                f"Embedder dimensions changed from {meta.dimensions} to "
+                f"{self._embedder.dimensions}. Run logseq-sync --rebuild to "
+                f"re-index from scratch."
             )
 
         # Guard: if graph path is inaccessible (e.g. container without vault mounted),

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -1221,6 +1221,7 @@ def test_vector_search_drops_tag_excluded_chunk(monkeypatch):
     ):
         mock_sm.return_value.load.return_value = ({}, meta)
         mock_stale.return_value = Mock(stale=False)
+        mock_emb.return_value.key = meta.embedder_key
         mock_emb.return_value.embed.return_value = [[0.1, 0.1, 0.1]]
         mock_db.open_readonly.return_value.search.return_value = [secret, ok]
 

--- a/tests/unit/vector/test_config.py
+++ b/tests/unit/vector/test_config.py
@@ -38,6 +38,16 @@ def test_returns_none_when_vector_missing(monkeypatch, tmp_path):
     assert load_vector_config() is None
 
 
+def test_returns_none_when_embedder_is_not_an_object(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {"enabled": True, "embedder": "ollama"},
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
+    assert load_vector_config() is None
+
+
 def test_returns_none_when_graph_path_missing(monkeypatch, tmp_path):
     path = _write_config(tmp_path, {
         "vector": {
@@ -56,10 +66,109 @@ def test_returns_none_for_unsupported_provider(monkeypatch, tmp_path):
         "vector": {
             "enabled": True,
             "db_path": "/tmp/db",
-            "embedder": {"provider": "openai", "model": "text-embedding-3-small"},
+            "embedder": {"provider": "cohere", "model": "embed-v4.0"},
         }
     })
     monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+    assert load_vector_config() is None
+
+
+def test_loads_openai_config_with_provider_defaults(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {
+            "enabled": True,
+            "embedder": {
+                "provider": "openai",
+                "api_key": "test-api-key",
+            },
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
+    config = load_vector_config()
+
+    assert config is not None
+    assert config.embedder.provider == "openai"
+    assert config.embedder.model == "text-embedding-3-small"
+    assert config.embedder.base_url == "https://api.openai.com/v1"
+    assert config.embedder.api_key == "test-api-key"
+    assert config.embedder.dimensions is None
+
+
+def test_returns_none_when_openai_api_key_missing(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {
+            "enabled": True,
+            "embedder": {"provider": "openai"},
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
+    assert load_vector_config() is None
+
+
+def test_loads_openai_compatible_config(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {
+            "enabled": True,
+            "embedder": {
+                "provider": "openai-compatible",
+                "model": "custom-embed-model",
+                "base_url": "https://embeddings.example.com/v1",
+                "api_key": "compatible-key",
+                "dimensions": 1024,
+            },
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
+    config = load_vector_config()
+
+    assert config is not None
+    assert config.embedder.provider == "openai-compatible"
+    assert config.embedder.model == "custom-embed-model"
+    assert config.embedder.base_url == "https://embeddings.example.com/v1"
+    assert config.embedder.api_key == "compatible-key"
+    assert config.embedder.dimensions == 1024
+
+
+@pytest.mark.parametrize("missing_field", ["model", "base_url"])
+def test_returns_none_when_openai_compatible_field_missing(
+    monkeypatch, tmp_path, missing_field
+):
+    embedder = {
+        "provider": "openai-compatible",
+        "model": "custom-embed-model",
+        "base_url": "https://embeddings.example.com/v1",
+    }
+    del embedder[missing_field]
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {"enabled": True, "embedder": embedder},
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
+    assert load_vector_config() is None
+
+
+@pytest.mark.parametrize("dimensions", [0, -1, 1.5, True, "1024"])
+def test_returns_none_for_invalid_dimensions(monkeypatch, tmp_path, dimensions):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/some/path",
+        "vector": {
+            "enabled": True,
+            "embedder": {
+                "provider": "openai",
+                "api_key": "test-api-key",
+                "dimensions": dimensions,
+            },
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+
     assert load_vector_config() is None
 
 

--- a/tests/unit/vector/test_embedder.py
+++ b/tests/unit/vector/test_embedder.py
@@ -3,12 +3,30 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mcp_logseq.config import EmbedderConfig
-from mcp_logseq.vector.embedder import OllamaEmbedder, create_embedder
+from mcp_logseq.vector.embedder import (
+    OllamaEmbedder,
+    OpenAICompatibleEmbedder,
+    create_embedder,
+)
 
 
 def _mock_response(vectors: list[list[float]]):
     mock = MagicMock()
     mock.json.return_value = {"embeddings": vectors}
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _mock_openai_response(vectors: list[list[float]], indices: list[int] | None = None):
+    mock = MagicMock()
+    if indices is None:
+        indices = list(range(len(vectors)))
+    mock.json.return_value = {
+        "data": [
+            {"object": "embedding", "embedding": vector, "index": index}
+            for vector, index in zip(vectors, indices)
+        ]
+    }
     mock.raise_for_status = MagicMock()
     return mock
 
@@ -94,6 +112,227 @@ def test_create_embedder_ollama():
 
 
 def test_create_embedder_unknown_provider():
-    config = EmbedderConfig(provider="openai", model="text-embedding-3-small")
+    config = EmbedderConfig(provider="cohere", model="embed-v4.0")
     with pytest.raises(ValueError, match="Unsupported embedder provider"):
         create_embedder(config)
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_embed_sends_auth_payload_and_restores_index_order(mock_post):
+    vectors = [[0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]
+    mock_post.return_value = _mock_openai_response(vectors, indices=[1, 0])
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1/",
+        api_key="test-api-key",
+    )
+
+    result = embedder.embed(["first", "second"])
+
+    assert result == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    mock_post.assert_called_once_with(
+        "https://api.openai.com/v1/embeddings",
+        json={
+            "model": "text-embedding-3-small",
+            "input": ["first", "second"],
+            "encoding_format": "float",
+        },
+        headers={"Authorization": "Bearer test-api-key"},
+        timeout=120,
+    )
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_compatible_omits_auth_and_sends_dimensions(mock_post):
+    mock_post.return_value = _mock_openai_response([[0.1] * 256])
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="http://localhost:8080/v1",
+        dimensions=256,
+    )
+
+    assert embedder.dimensions == 256
+    result = embedder.embed(["test"])
+
+    assert len(result[0]) == 256
+    call = mock_post.call_args
+    assert call.kwargs["headers"] == {}
+    assert call.kwargs["json"]["dimensions"] == 256
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_dimensions_probes_when_not_configured(mock_post):
+    mock_post.return_value = _mock_openai_response([[0.1] * 1536])
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1",
+        api_key="test-api-key",
+    )
+
+    assert embedder.dimensions == 1536
+    mock_post.assert_called_once()
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_embed_empty_list_returns_empty(mock_post):
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="http://localhost:8080/v1",
+    )
+
+    assert embedder.embed([]) == []
+    mock_post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "response_data,match",
+    [
+        ({"data": []}, "returned 0 embeddings for 1 texts"),
+        ({"data": [{"index": 0}]}, "missing a numeric embedding"),
+        (
+            {"data": [{"index": 1, "embedding": [0.1, 0.2]}]},
+            "invalid embedding indices",
+        ),
+        (
+            {"data": [{"index": 0, "embedding": [0.1, "bad"]}]},
+            "missing a numeric embedding",
+        ),
+    ],
+)
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_rejects_malformed_response(mock_post, response_data, match):
+    response = MagicMock()
+    response.json.return_value = response_data
+    response.raise_for_status = MagicMock()
+    mock_post.return_value = response
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="http://localhost:8080/v1",
+    )
+
+    with pytest.raises(RuntimeError, match=match):
+        embedder.embed(["test"])
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_rejects_inconsistent_dimensions(mock_post):
+    mock_post.return_value = _mock_openai_response([[0.1, 0.2], [0.3]])
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="http://localhost:8080/v1",
+    )
+
+    with pytest.raises(RuntimeError, match="inconsistent dimensions"):
+        embedder.embed(["first", "second"])
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_rejects_configured_dimension_mismatch(mock_post):
+    mock_post.return_value = _mock_openai_response([[0.1, 0.2]])
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="http://localhost:8080/v1",
+        dimensions=3,
+    )
+
+    with pytest.raises(RuntimeError, match="configured for 3 dimensions but returned 2"):
+        embedder.embed(["test"])
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_connection_error_raises_without_exposing_api_key(mock_post):
+    import requests as req
+    mock_post.side_effect = req.ConnectionError()
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1",
+        api_key="secret-api-key",
+    )
+
+    with pytest.raises(RuntimeError, match="Cannot connect to OpenAI") as exc:
+        embedder.embed(["test"])
+    assert "secret-api-key" not in str(exc.value)
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_http_error_raises_runtime_error(mock_post):
+    import requests as req
+    response = MagicMock()
+    response.raise_for_status.side_effect = req.HTTPError("401 Unauthorized")
+    mock_post.return_value = response
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1",
+        api_key="test-api-key",
+    )
+
+    with pytest.raises(RuntimeError, match="OpenAI embedding request failed"):
+        embedder.embed(["test"])
+
+
+@patch("mcp_logseq.vector.embedder.requests.post")
+def test_openai_invalid_json_raises_runtime_error(mock_post):
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.side_effect = ValueError("invalid JSON")
+    mock_post.return_value = response
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1",
+        api_key="test-api-key",
+    )
+
+    with pytest.raises(RuntimeError, match="returned invalid JSON"):
+        embedder.embed(["test"])
+
+
+def test_openai_key_includes_configured_dimensions():
+    embedder = OpenAICompatibleEmbedder(
+        provider="openai",
+        model="text-embedding-3-small",
+        base_url="https://api.openai.com/v1",
+        api_key="test-api-key",
+        dimensions=512,
+    )
+    assert embedder.key == "openai/text-embedding-3-small/dimensions=512"
+
+
+def test_create_embedder_openai():
+    config = EmbedderConfig(
+        provider="openai",
+        model="text-embedding-3-small",
+        api_key="test-api-key",
+    )
+    embedder = create_embedder(config)
+    assert isinstance(embedder, OpenAICompatibleEmbedder)
+    assert embedder.key == "openai/text-embedding-3-small"
+
+
+def test_create_embedder_openai_requires_api_key():
+    config = EmbedderConfig(
+        provider="openai",
+        model="text-embedding-3-small",
+    )
+    with pytest.raises(ValueError, match="requires api_key"):
+        create_embedder(config)
+
+
+def test_create_embedder_openai_compatible():
+    config = EmbedderConfig(
+        provider="openai-compatible",
+        model="custom-model",
+        base_url="https://embeddings.example.com/v1",
+    )
+    embedder = create_embedder(config)
+    assert isinstance(embedder, OpenAICompatibleEmbedder)
+    assert embedder.key == "openai-compatible/custom-model"

--- a/tests/unit/vector/test_index.py
+++ b/tests/unit/vector/test_index.py
@@ -55,6 +55,7 @@ class TestVectorSearchReadOnly:
             patch("mcp_logseq.vector.index.VectorDB") as mock_db,
         ):
             mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
             mock_emb.return_value.embed.return_value = [[0.1] * 2560]
             mock_db.open_readonly.return_value.search.return_value = []
 
@@ -79,6 +80,7 @@ class TestVectorSearchReadOnly:
             patch("mcp_logseq.vector.index.VectorDB") as mock_db,
         ):
             mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
             mock_emb.return_value.embed.return_value = [[0.1] * 2560]
             mock_db.open_readonly.return_value.search.return_value = []
 
@@ -96,6 +98,7 @@ class TestVectorSearchReadOnly:
             patch("mcp_logseq.vector.index.VectorDB") as mock_db,
         ):
             mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
             mock_emb.return_value.embed.return_value = [[0.1] * 2560]
             mock_db.open_readonly.return_value.search.return_value = []
 
@@ -116,6 +119,7 @@ class TestVectorSearchReadOnly:
             patch("mcp_logseq.vector.index.VectorDB") as mock_db,
         ):
             mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
             mock_emb.return_value.embed.return_value = [[0.1] * 2560]
             mock_db.open_readonly.side_effect = RuntimeError("Vector DB not initialized.")
 
@@ -133,11 +137,52 @@ class TestVectorSearchReadOnly:
             patch("mcp_logseq.vector.index.VectorDB") as mock_db,
         ):
             mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
             mock_emb.return_value.embed.return_value = [[0.1] * 2560]
             mock_db.open_readonly.return_value.search.return_value = []
 
             handler.run_tool({"query": "test"})
             mock_sm.return_value.save.assert_not_called()
+
+    def test_search_refuses_embedder_mismatch(self):
+        config = _make_config()
+        handler = VectorSearchToolHandler(config)
+
+        with (
+            patch("mcp_logseq.vector.index.StateManager") as mock_sm,
+            patch("mcp_logseq.vector.index.check_staleness", return_value=_make_fresh_report()),
+            patch("mcp_logseq.vector.index.create_embedder") as mock_emb,
+            patch("mcp_logseq.vector.index.VectorDB") as mock_db,
+        ):
+            mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = "openai/text-embedding-3-small"
+
+            results = handler.run_tool({"query": "test"})
+
+            assert "does not match vector DB embedder" in results[0].text
+            assert "logseq-sync --rebuild" in results[0].text
+            mock_emb.return_value.embed.assert_not_called()
+            mock_db.open_readonly.assert_not_called()
+
+    def test_search_refuses_dimension_mismatch(self):
+        config = _make_config()
+        handler = VectorSearchToolHandler(config)
+
+        with (
+            patch("mcp_logseq.vector.index.StateManager") as mock_sm,
+            patch("mcp_logseq.vector.index.check_staleness", return_value=_make_fresh_report()),
+            patch("mcp_logseq.vector.index.create_embedder") as mock_emb,
+            patch("mcp_logseq.vector.index.VectorDB") as mock_db,
+        ):
+            mock_sm.return_value.load.return_value = ({}, _make_meta())
+            mock_emb.return_value.key = _make_meta().embedder_key
+            mock_emb.return_value.embed.return_value = [[0.1] * 512]
+
+            results = handler.run_tool({"query": "test"})
+
+            assert "returned 512 dimensions but the vector DB uses 2560" in results[0].text
+            assert "logseq-sync --rebuild" in results[0].text
+            mock_db.open_readonly.assert_not_called()
 
 
 class TestSyncVectorDBInertPointer:
@@ -180,6 +225,7 @@ class TestSyncVectorDBInertPointer:
         handler = SyncVectorDBToolHandler(config)
 
         desc = handler.get_tool_description().description
+        assert desc is not None
         assert "logseq-sync" in desc
         assert "host that owns the DB" in desc
 

--- a/tests/unit/vector/test_logseq_sync.py
+++ b/tests/unit/vector/test_logseq_sync.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -7,7 +8,8 @@ portalocker = pytest.importorskip(
     "portalocker", reason="requires the optional 'vector' extra"
 )
 
-from mcp_logseq.bin.logseq_sync import _acquire_sync_lock, _release_sync_lock
+from mcp_logseq.bin.logseq_sync import _acquire_sync_lock, _release_sync_lock, _run_sync
+from mcp_logseq.config import EmbedderConfig
 
 
 def test_acquire_and_release_lock(tmp_path):
@@ -74,3 +76,45 @@ def test_release_swallows_exceptions(tmp_path):
         mock_pl.unlock.side_effect = RuntimeError("unexpected")
         # Should not raise
         _release_sync_lock(lock_file)
+
+
+@patch("mcp_logseq.vector.sync.SyncEngine")
+@patch("mcp_logseq.vector.state.StateManager")
+@patch("mcp_logseq.vector.db.VectorDB")
+@patch("mcp_logseq.vector.embedder.create_embedder")
+def test_run_sync_prints_selected_provider(
+    mock_create_embedder,
+    mock_vector_db,
+    mock_state_manager,
+    mock_sync_engine,
+    tmp_path,
+    capsys,
+):
+    embedder = MagicMock()
+    embedder.dimensions = 1536
+    embedder.key = "openai/text-embedding-3-small"
+    mock_create_embedder.return_value = embedder
+    mock_sync_engine.return_value.sync.return_value = SimpleNamespace(
+        duration_ms=10,
+        added=1,
+        updated=0,
+        deleted=0,
+        skipped=0,
+    )
+    config = SimpleNamespace(
+        db_path=str(tmp_path / "db"),
+        graph_path=str(tmp_path / "graph"),
+        embedder=EmbedderConfig(
+            provider="openai",
+            model="text-embedding-3-small",
+            api_key="test-api-key",
+        ),
+    )
+
+    _run_sync(config)
+
+    output = capsys.readouterr().out
+    assert "Connecting to embedding provider openai (text-embedding-3-small)" in output
+    assert "Ollama" not in output
+    mock_vector_db.open.assert_called_once_with(str(tmp_path / "db"), 1536)
+    mock_state_manager.assert_called_once_with(str(tmp_path / "db"))

--- a/tests/unit/vector/test_sync.py
+++ b/tests/unit/vector/test_sync.py
@@ -146,6 +146,25 @@ def test_sync_aborts_on_embedder_mismatch(tmp_path):
         engine.sync()
 
 
+def test_sync_aborts_on_dimension_mismatch(tmp_path):
+    config = _make_config(str(tmp_path), str(tmp_path / "db"))
+    db = MagicMock()
+    state_mgr = MagicMock()
+    state_mgr.load.return_value = (
+        {},
+        SyncMeta(
+            embedder_key="ollama/nomic-embed-text",
+            dimensions=512,
+            last_full_sync=None,
+        ),
+    )
+    embedder = _make_embedder(dims=768)
+
+    engine = SyncEngine(config, db, state_mgr, embedder)
+    with pytest.raises(RuntimeError, match="dimensions changed from 512 to 768"):
+        engine.sync()
+
+
 def test_sync_skips_unchanged_files(tmp_path):
     md = tmp_path / "page.md"
     md.write_text("- Some content for testing here\n")


### PR DESCRIPTION
## Summary

Closes #77

- add OpenAI and OpenAI-compatible embedding providers alongside Ollama
- validate provider-specific configuration and embedding API responses
- prevent queries or incremental syncs from mixing incompatible embedding spaces
- document provider setup, rebuild requirements, and hosted-provider privacy considerations

## Validation

(Re-run after rebasing onto main, with `LOGSEQ_CONFIG_FILE` unset — the
"2 existing failures" previously reported here were environment leakage from a
vector-enabled config being picked up during the test run, which registered
the 3 vector tools.)

- `uv build` — passed.
- `env -u LOGSEQ_CONFIG_FILE uv run --extra vector pytest` — 601 passed, 0 failed.
- `uv run pyright src tests` — 63 pre-existing project-wide diagnostics, none
  in files touched by this branch (primarily untouched Logseq tool, DB, and
  integration-test typing).

