### PR TITLE
chore: remove unused imports and clarify sync loop unpacking

### DIFF
--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import sys
 from collections.abc import Sequence
@@ -23,8 +22,6 @@ logging.basicConfig(
 logger = logging.getLogger("mcp-logseq")
 
 # Add a file handler to keep logs (in user's home directory to avoid permission issues)
-import tempfile
-
 log_dir = os.path.expanduser("~/.cache/mcp-logseq")
 os.makedirs(log_dir, exist_ok=True)
 log_file = os.path.join(log_dir, "mcp_logseq.log")

--- a/src/mcp_logseq/vector/db.py
+++ b/src/mcp_logseq/vector/db.py
@@ -11,7 +11,6 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from mcp_logseq.vector.types import LogseqChunk, SearchParams, SearchResult
 

--- a/src/mcp_logseq/vector/sync.py
+++ b/src/mcp_logseq/vector/sync.py
@@ -11,7 +11,6 @@ import logging
 import os
 import shutil
 import time
-from datetime import datetime, timezone
 from pathlib import Path
 
 from mcp_logseq.config import VectorConfig
@@ -126,11 +125,10 @@ class SyncEngine:
                 continue
             files_to_process.append((path_str, file_path))
 
-        # Delete chunks for changed and deleted files
-        for path_str in files_to_process:
-            path_str_key = path_str[0]
-            if path_str_key in state:
-                self._db.delete_by_ids(state[path_str_key].chunk_ids)
+        # Delete chunks for changed files (deleted files handled separately below)
+        for path_str, _file_path in files_to_process:
+            if path_str in state:
+                self._db.delete_by_ids(state[path_str].chunk_ids)
                 updated += 1
             else:
                 added += 1


### PR DESCRIPTION
## Summary

Small lint cleanup, no behavior change:

- **server.py**: drop unused `json` / `tempfile` imports
- **vector/db.py**: drop unused `TYPE_CHECKING` import
- **vector/sync.py**: drop unused `datetime` import; unpack the `(path_str, file_path)` tuple explicitly instead of indexing `path_str[0]`

## Test plan

- Full suite passes: 569 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)