### PR TITLE
test: skip vector tests cleanly when the vector extra isn't installed

### DIFF
--- a/tests/unit/vector/test_asyncio_regression.py
+++ b/tests/unit/vector/test_asyncio_regression.py
@@ -23,6 +23,8 @@ import json
 
 import pytest
 
+pytest.importorskip("lancedb", reason="requires the optional 'vector' extra")
+
 from mcp_logseq.vector.db import VectorDB
 from mcp_logseq.vector.types import LogseqChunk
 
@@ -181,7 +183,7 @@ class TestVectorDBStatusViaToThread:
 
     def test_completes_via_to_thread_no_deadlock(self, tiny_db):
         """Regression: status handler must not block or deadlock via asyncio.to_thread()."""
-        from unittest.mock import MagicMock, patch
+        from unittest.mock import MagicMock
 
         from mcp_logseq.vector.index import VectorDBStatusToolHandler
 

--- a/tests/unit/vector/test_logseq_sync.py
+++ b/tests/unit/vector/test_logseq_sync.py
@@ -1,8 +1,11 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import portalocker
 import pytest
+
+portalocker = pytest.importorskip(
+    "portalocker", reason="requires the optional 'vector' extra"
+)
 
 from mcp_logseq.bin.logseq_sync import _acquire_sync_lock, _release_sync_lock
 


### PR DESCRIPTION
## Summary

Fixes #66 — a plain `uv run pytest` aborted the entire collection with `ModuleNotFoundError: No module named 'portalocker'` when the optional `vector` extra wasn't installed.

- `tests/unit/vector/test_logseq_sync.py`: guard the top-level `import portalocker` with `pytest.importorskip` (this was the collection abort)
- `tests/unit/vector/test_asyncio_regression.py`: `importorskip("lancedb")` at module level — these tests use a real LanceDB table, so without the extra they errored at runtime
- drop two unused `unittest.mock` imports in the touched files

Same pattern `test_namespace_access.py` already uses. #68 documented the workaround; this makes the default command safe regardless.

## Test plan

- Without extras (`uv sync --dev`): **557 passed, 2 skipped** — no collection abort
- With extras (`uv sync --dev --extra vector`): **569 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)