### PR TITLE
feat(vector): index-time namespace scoping for the vector DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,20 @@ Matching is segment-based and case-insensitive: `work` matches `work` and `work/
 
 Access control is enforced at the **page** level and applied across every tool: list/search/query results omit blocked pages, direct page/block access and backlinks are denied, and vector search is filtered. Block-level results from `search` and `query` are resolved back to their owning page, so a block belonging to a restricted page is filtered out of those results too.
 
+**Index-time namespace scoping (vector DB only).** The keys above are *query-time*: every page is embedded, and blocked ones are filtered out of each response. For the vector DB you can also scope at *index time* — decide which namespaces are embedded into the DB **at all** — with `include_namespaces` / `exclude_namespaces` inside the `vector` block of the config file:
+
+```json
+{
+  "vector": {
+    "enabled": true,
+    "include_namespaces": ["work"],
+    "exclude_namespaces": ["work/secret"]
+  }
+}
+```
+
+This is global (it shapes the shared DB for every consumer), and it keeps unwanted content off disk entirely rather than filtering it on read — useful for secrets you never want embedded, or to keep the index small when everyone only cares about a subset. Matching is the same segment-based, case-insensitive rule. Because it changes what the index contains, it only takes effect after a full re-index: `logseq-sync --rebuild`.
+
 ### 🌐 Serving over HTTP, multi-profile & TLS
 
 By default the server speaks **stdio** — your client spawns it as a subprocess, and most users need nothing more. To serve **sandboxed or remote clients** over the network, `mcp-logseq` can run as a long-lived HTTP service with bearer auth, per-profile isolation, and TLS:

--- a/src/mcp_logseq/config.py
+++ b/src/mcp_logseq/config.py
@@ -20,10 +20,17 @@ Example config.json:
     },
     "include_journals": true,
     "exclude_tags": ["private"],
+    "include_namespaces": ["work"],
+    "exclude_namespaces": ["work/secret"],
     "min_chunk_length": 50,
     "watch_debounce_ms": 5000
   }
 }
+
+The vector-block "include_namespaces" / "exclude_namespaces" are INDEX-TIME:
+they decide which pages are embedded at all (global to the DB), unlike the
+root-level namespace keys, which filter query results per instance. Changing
+them takes effect only after `logseq-sync --rebuild`.
 
 Supported embedder providers are "ollama", "openai", and
 "openai-compatible". Hosted providers may also use "api_key" and "dimensions"
@@ -57,6 +64,8 @@ class VectorConfig:
     graph_path: str                         # logseq_graph_path from root config
     include_journals: bool = True
     exclude_tags: list[str] = field(default_factory=list)
+    include_namespaces: list[str] = field(default_factory=list)
+    exclude_namespaces: list[str] = field(default_factory=list)
     min_chunk_length: int = 50
     watch_debounce_ms: int = 5000
 
@@ -159,6 +168,8 @@ def load_vector_config() -> VectorConfig | None:
         graph_path=os.path.expanduser(graph_path),
         include_journals=vector_raw.get("include_journals", True),
         exclude_tags=vector_raw.get("exclude_tags", []),
+        include_namespaces=vector_raw.get("include_namespaces", []),
+        exclude_namespaces=vector_raw.get("exclude_namespaces", []),
         min_chunk_length=vector_raw.get("min_chunk_length", 50),
         watch_debounce_ms=vector_raw.get("watch_debounce_ms", 5000),
     )

--- a/src/mcp_logseq/namespace.py
+++ b/src/mcp_logseq/namespace.py
@@ -1,0 +1,30 @@
+"""Pure, side-effect-free namespace matching.
+
+Shared by the query-time ACL layer (``tools.py``) and the index-time vector
+indexer (``vector/chunker.py``). Kept dependency-free so the sync writer, which
+runs without ``LOGSEQ_API_TOKEN``, can import it without triggering ``tools.py``'s
+import-time environment checks.
+"""
+
+from __future__ import annotations
+
+
+def namespace_matches(page_name: str, ns: str) -> bool:
+    """Segment-based, case-insensitive namespace match.
+
+    'work' matches 'work' and 'work/...'; it does NOT match 'workshop'.
+    """
+    p = page_name.lower()
+    n = ns.lower().rstrip("/")
+    if not n:
+        return False
+    return p == n or p.startswith(n + "/")
+
+
+def is_namespace_blocked(page_name: str, include: list[str], exclude: list[str]) -> bool:
+    """Apply namespace rules. Exclude wins; include is a strict allow-list."""
+    if any(namespace_matches(page_name, n) for n in exclude):
+        return True
+    if include and not any(namespace_matches(page_name, n) for n in include):
+        return True
+    return False

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from . import logseq
 from . import parser
 from .config import load_exclude_tags, load_include_namespaces, load_exclude_namespaces
+from .namespace import is_namespace_blocked as _is_namespace_blocked
 from mcp.types import Tool, TextContent
 
 logger = logging.getLogger("mcp-logseq")
@@ -121,27 +122,6 @@ def _is_page_excluded(page: dict, exclude_tags: list[str]) -> bool:
 
 class AccessDenied(RuntimeError):
     """Raised when a tool is blocked from accessing a restricted page."""
-
-
-def _namespace_matches(page_name: str, ns: str) -> bool:
-    """Segment-based, case-insensitive namespace match.
-
-    'work' matches 'work' and 'work/...'; it does NOT match 'workshop'.
-    """
-    p = page_name.lower()
-    n = ns.lower().rstrip("/")
-    if not n:
-        return False
-    return p == n or p.startswith(n + "/")
-
-
-def _is_namespace_blocked(page_name: str, include: list[str], exclude: list[str]) -> bool:
-    """Apply namespace rules. Exclude wins; include is a strict allow-list."""
-    if any(_namespace_matches(page_name, n) for n in exclude):
-        return True
-    if include and not any(_namespace_matches(page_name, n) for n in include):
-        return True
-    return False
 
 
 def _is_page_blocked(page: dict | None, page_name: str) -> bool:

--- a/src/mcp_logseq/vector/chunker.py
+++ b/src/mcp_logseq/vector/chunker.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 
 from mcp_logseq.config import VectorConfig
+from mcp_logseq.namespace import is_namespace_blocked
 from mcp_logseq.parser import BlockNode, parse_content
 from mcp_logseq.vector.types import LogseqChunk
 
@@ -132,6 +133,13 @@ def chunk_file(file_path: Path, config: VectorConfig) -> list[LogseqChunk]:
     # Apply exclude_tags filter
     if config.exclude_tags and any(t in config.exclude_tags for t in tags):
         logger.debug(f"Skipping {page_title}: excluded by tag filter")
+        return []
+
+    # Apply index-time namespace filter (global: shapes what the DB contains)
+    if is_namespace_blocked(
+        page_title, config.include_namespaces, config.exclude_namespaces
+    ):
+        logger.debug(f"Skipping {page_title}: excluded by namespace filter")
         return []
 
     # Journal date detection

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -81,8 +81,8 @@ def test_exclude_tags_still_works_after_refactor(monkeypatch):
 
 # --- _namespace_matches / _is_namespace_blocked / _is_page_blocked ---
 
+from mcp_logseq.namespace import namespace_matches as _namespace_matches
 from mcp_logseq.tools import (
-    _namespace_matches,
     _is_namespace_blocked,
     _is_page_blocked,
     AccessDenied,

--- a/tests/unit/vector/test_chunker.py
+++ b/tests/unit/vector/test_chunker.py
@@ -119,6 +119,35 @@ def test_chunk_file_exclude_tags_filters_page(tmp_path):
     assert chunks == []
 
 
+def test_chunk_file_exclude_namespace_filters_page(tmp_path):
+    md_file = tmp_path / "Work___Secret.md"
+    md_file.write_text("- Confidential project notes with enough content here\n")
+    config = _make_config(graph_path=str(tmp_path), exclude_namespaces=["Work/Secret"])
+
+    chunks = chunk_file(md_file, config)
+    assert chunks == []
+
+
+def test_chunk_file_include_namespace_allowlist(tmp_path):
+    work = tmp_path / "Work___ProjectA.md"
+    work.write_text("- Work project notes with enough content to index here\n")
+    personal = tmp_path / "Personal___Health.md"
+    personal.write_text("- Personal health notes with enough content here too\n")
+    config = _make_config(graph_path=str(tmp_path), include_namespaces=["Work"])
+
+    assert chunk_file(personal, config) == []
+    assert len(chunk_file(work, config)) >= 1
+
+
+def test_chunk_file_namespace_match_is_segment_based(tmp_path):
+    # "Work" must not block "Workshop" — segment match, not prefix string match.
+    md_file = tmp_path / "Workshop___Notes.md"
+    md_file.write_text("- Workshop notes with plenty of content to index here\n")
+    config = _make_config(graph_path=str(tmp_path), exclude_namespaces=["Work"])
+
+    assert len(chunk_file(md_file, config)) >= 1
+
+
 def test_chunk_file_skips_journals_when_disabled(tmp_path):
     md_file = tmp_path / "2024_03_15.md"
     md_file.write_text("- Journal content with enough characters here\n")

--- a/tests/unit/vector/test_config.py
+++ b/tests/unit/vector/test_config.py
@@ -202,6 +202,38 @@ def test_loads_valid_config(monkeypatch, tmp_path):
     assert config.embedder.model == "nomic-embed-text"
 
 
+def test_loads_index_time_namespaces(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/my/graph/pages",
+        "vector": {
+            "enabled": True,
+            "embedder": {"provider": "ollama", "model": "nomic-embed-text"},
+            "include_namespaces": ["Work", "Projects"],
+            "exclude_namespaces": ["Work/Secret"],
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+    config = load_vector_config()
+    assert config is not None
+    assert config.include_namespaces == ["Work", "Projects"]
+    assert config.exclude_namespaces == ["Work/Secret"]
+
+
+def test_index_time_namespaces_default_empty(monkeypatch, tmp_path):
+    path = _write_config(tmp_path, {
+        "logseq_graph_path": "/my/graph/pages",
+        "vector": {
+            "enabled": True,
+            "embedder": {"provider": "ollama", "model": "nomic-embed-text"},
+        },
+    })
+    monkeypatch.setenv("LOGSEQ_CONFIG_FILE", path)
+    config = load_vector_config()
+    assert config is not None
+    assert config.include_namespaces == []
+    assert config.exclude_namespaces == []
+
+
 def test_applies_defaults(monkeypatch, tmp_path):
     path = _write_config(tmp_path, {
         "logseq_graph_path": "/my/graph/pages",


### PR DESCRIPTION
## Summary
- Add `vector.include_namespaces` / `vector.exclude_namespaces` to the config file — index-time, global namespace scoping for the vector DB, symmetric with the existing index-time `vector.exclude_tags`.
- Pages in a blocked namespace are never embedded into the DB at all, unlike the existing root-level namespace keys which filter query results per instance. Keeps unwanted content off disk entirely and shrinks the index. Takes effect after `logseq-sync --rebuild`.
- Extract the segment-based namespace matcher into a side-effect-free `namespace.py`, shared by `tools.py` (query-time ACL) and `chunker.py` (index-time). Removes duplicated matching logic and avoids the chunker depending on `tools.py`'s import-time `LOGSEQ_API_TOKEN` guard, since the sync writer runs without that token.

## Test plan
- [x] `uv run pytest` — 606 passed
- [x] New unit tests for config parsing (`include_namespaces`/`exclude_namespaces`, defaults) and chunker filtering (exclude, include allow-list, segment-based match so `Work` doesn't block `Workshop`)
- [x] Existing namespace ACL tests (`test_namespace_access.py`) pass unchanged after the matcher extraction