### PR TITLE
refactor: move env config to lazy Settings, drop import-time side effects (A1)

### DIFF
--- a/src/mcp_logseq/__init__.py
+++ b/src/mcp_logseq/__init__.py
@@ -77,7 +77,6 @@ def main():
 
 # Optionally expose other important items at package level.
 # ``server`` is intentionally NOT listed: it's imported lazily inside ``main``
-# (eager import would trigger server.py's import-time LOGSEQ_API_TOKEN raise on
-# the http path). Submodule access via ``from mcp_logseq.server import ...``
-# still works.
+# to keep package import light (the http path doesn't need it). Submodule
+# access via ``from mcp_logseq.server import ...`` still works.
 __all__ = ['main', 'parse_args']

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -38,18 +38,7 @@ except Exception as e:
 load_dotenv()
 
 from . import tools
-
-# Load environment variables with more verbose logging
-api_token = os.getenv("LOGSEQ_API_TOKEN")
-if not api_token:
-    logger.error("LOGSEQ_API_TOKEN not found in environment")
-    raise ValueError("LOGSEQ_API_TOKEN environment variable required")
-else:
-    logger.info("Found LOGSEQ_API_TOKEN in environment")
-    logger.debug("API token validation successful")
-
-api_url = os.getenv("LOGSEQ_API_URL", "http://localhost:12315")
-logger.info(f"Using API URL: {api_url}")
+from .settings import get_settings
 
 # Names of the genuine write tools — tools that mutate Logseq content. When
 # ``read_only`` is set these are NOT registered. ``sync_vector_db`` is NOT in
@@ -217,6 +206,9 @@ def get_tool_handler(name: str) -> tools.ToolHandler | None:
 
 async def main(read_only: bool = False):
     logger.info(f"Starting LogSeq MCP server (read_only={read_only})")
+    # Fail fast at startup (not import time) if configuration is invalid.
+    settings = get_settings()
+    logger.info(f"Using LogSeq API at {settings.protocol}://{settings.host}:{settings.port}")
     from mcp.server.stdio import stdio_server
 
     app, _ = build_app(read_only=read_only)

--- a/src/mcp_logseq/settings.py
+++ b/src/mcp_logseq/settings.py
@@ -1,0 +1,94 @@
+"""Lazy, validated runtime configuration for the LogSeq API client.
+
+All environment reading and validation lives here, in ``load_settings()``.
+Importing this module (or any module that uses it) has no side effects;
+validation happens at startup via ``get_settings()``, not at import time.
+"""
+
+import functools
+import logging
+import math
+import os
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+logger = logging.getLogger("mcp-logseq")
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Resolved LogSeq API connection settings."""
+
+    api_key: str
+    protocol: str
+    host: str
+    port: int
+    verify_ssl: bool
+    connect_timeout: float
+    read_timeout: float
+    db_mode: bool
+
+    @property
+    def timeout(self) -> tuple[float, float]:
+        return (self.connect_timeout, self.read_timeout)
+
+
+def _parse_positive_float_env(name: str, default: float) -> float:
+    raw_value = os.getenv(name, "").strip()
+    if not raw_value:
+        return default
+
+    try:
+        value = float(raw_value)
+    except ValueError:
+        value = None
+
+    if value is None or not math.isfinite(value) or value <= 0:
+        logger.warning(
+            f"{name} must be a positive number of seconds, got {raw_value!r}; "
+            f"falling back to default {default}"
+        )
+        return default
+
+    return value
+
+
+def load_settings() -> Settings:
+    """Read and validate configuration from the environment.
+
+    Raises ``ValueError`` if ``LOGSEQ_API_TOKEN`` is missing.
+    """
+    api_key = os.getenv("LOGSEQ_API_TOKEN", "")
+    if api_key == "":
+        raise ValueError("LOGSEQ_API_TOKEN environment variable required")
+
+    api_url = os.getenv("LOGSEQ_API_URL", "http://localhost:12315")
+    parsed_url = urlparse(api_url)
+    protocol = parsed_url.scheme or "http"
+
+    verify_ssl_env = os.getenv("LOGSEQ_VERIFY_SSL")
+    if verify_ssl_env is not None:
+        verify_ssl = verify_ssl_env.lower() not in ("0", "false", "no")
+    else:
+        verify_ssl = protocol == "https"
+
+    return Settings(
+        api_key=api_key,
+        protocol=protocol,
+        host=parsed_url.hostname or "127.0.0.1",
+        port=parsed_url.port or 12315,
+        verify_ssl=verify_ssl,
+        connect_timeout=_parse_positive_float_env("LOGSEQ_API_CONNECT_TIMEOUT", 3),
+        read_timeout=_parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6),
+        db_mode=os.getenv("LOGSEQ_DB_MODE", "").lower() in ("1", "true", "yes"),
+    )
+
+
+@functools.cache
+def get_settings() -> Settings:
+    """Return the process-wide ``Settings``, loading them on first use.
+
+    Cached for the life of the process; call ``get_settings.cache_clear()``
+    (tests) to force a reload from the environment.
+    """
+    return load_settings()

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -1,76 +1,35 @@
 import json
-import math
-import os
 import re
 import logging
 from typing import Any
-from urllib.parse import urlparse
 from . import logseq
 from . import parser
 from .config import load_exclude_tags, load_include_namespaces, load_exclude_namespaces
 from .namespace import is_namespace_blocked as _is_namespace_blocked
+from .settings import get_settings
 from mcp.types import Tool, TextContent
 
 logger = logging.getLogger("mcp-logseq")
 
-api_key = os.getenv("LOGSEQ_API_TOKEN", "")
-if api_key == "":
-    raise ValueError("LOGSEQ_API_TOKEN environment variable required")
-else:
-    logger.info("Found LOGSEQ_API_TOKEN in environment")
-    logger.debug(f"API Token starts with: {api_key[:5]}...")
-
-_api_url = os.getenv("LOGSEQ_API_URL", "http://localhost:12315")
-_parsed_url = urlparse(_api_url)
-_api_protocol = _parsed_url.scheme or "http"
-_api_host = _parsed_url.hostname or "127.0.0.1"
-_api_port = _parsed_url.port or 12315
-
-def _parse_positive_float_env(name: str, default: float) -> float:
-    raw_value = os.getenv(name, "").strip()
-    if not raw_value:
-        return default
-
-    try:
-        value = float(raw_value)
-    except ValueError:
-        value = None
-
-    if value is None or not math.isfinite(value) or value <= 0:
-        logger.warning(
-            f"{name} must be a positive number of seconds, got {raw_value!r}; "
-            f"falling back to default {default}"
-        )
-        return default
-
-    return value
-
-
-_api_connect_timeout = _parse_positive_float_env("LOGSEQ_API_CONNECT_TIMEOUT", 3)
-_api_read_timeout = _parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6)
-_api_timeout = (_api_connect_timeout, _api_read_timeout)
-
-_verify_ssl_env = os.getenv("LOGSEQ_VERIFY_SSL")
-if _verify_ssl_env is not None:
-    _api_verify_ssl = _verify_ssl_env.lower() not in ("0", "false", "no")
-else:
-    _api_verify_ssl = _api_protocol == "https"
-
-_db_mode = os.getenv("LOGSEQ_DB_MODE", "").lower() in ("1", "true", "yes")
 _exclude_tags: list[str] = load_exclude_tags()
 _include_namespaces: list[str] = load_include_namespaces()
 _exclude_namespaces: list[str] = load_exclude_namespaces()
 
 
+def _get_db_mode() -> bool:
+    return get_settings().db_mode
+
+
 def _make_api() -> logseq.LogSeq:
+    settings = get_settings()
     return logseq.LogSeq(
-        api_key=api_key,
-        protocol=_api_protocol,
-        host=_api_host,
-        port=_api_port,
-        verify_ssl=_api_verify_ssl,
-        timeout=_api_timeout,
-        db_mode=_db_mode,
+        api_key=settings.api_key,
+        protocol=settings.protocol,
+        host=settings.host,
+        port=settings.port,
+        verify_ssl=settings.verify_ssl,
+        timeout=settings.timeout,
+        db_mode=settings.db_mode,
     )
 
 
@@ -458,7 +417,7 @@ class GetPageContentToolHandler(ToolHandler):
 
         # In DB-mode, properties are NOT embedded in content — render from dict
         # In Markdown-mode, properties are already in block content — skip to avoid duplicates
-        if _db_mode:
+        if _get_db_mode():
             properties = block.get("properties", {})
             if properties:
                 for key, value in properties.items():
@@ -547,7 +506,7 @@ class GetPageContentToolHandler(ToolHandler):
             # Handle JSON format request
             if args.get("format") == "json":
                 # In DB mode with resolve_refs, enrich JSON with resolved page names
-                if _db_mode and args.get("resolve_refs", True):
+                if _get_db_mode() and args.get("resolve_refs", True):
                     blocks = result.get("blocks", [])
                     page_uuids = _collect_block_uuids(blocks)
                     if page_uuids:
@@ -569,7 +528,7 @@ class GetPageContentToolHandler(ToolHandler):
             # Fetch DB-mode class properties (only when LOGSEQ_DB_MODE is enabled)
             db_properties = {}
             uuid_map: dict[str, str] = {}
-            if _db_mode:
+            if _get_db_mode():
                 try:
                     db_properties = api.get_blocks_db_properties(blocks)
                     logger.info(f"DB-mode properties found for {len(db_properties)} blocks")
@@ -956,7 +915,7 @@ class GetBlockToolHandler(ToolHandler):
 
             # Fetch DB-mode class properties when enabled
             db_properties = {}
-            if _db_mode:
+            if _get_db_mode():
                 try:
                     db_properties = api.get_blocks_db_properties([result])
                     logger.info(f"DB-mode properties found for {len(db_properties)} blocks")
@@ -1258,9 +1217,9 @@ class SearchToolHandler(ToolHandler):
         text formatters, but preserves the raw fields (uuid, page) so callers
         can build logseq:// deep links without follow-up calls.
         """
-        out: dict = {"query": query, "mode": "db" if _db_mode else "markdown"}
+        out: dict = {"query": query, "mode": "db" if _get_db_mode() else "markdown"}
 
-        if _db_mode:
+        if _get_db_mode():
             blocks = result.get("blocks", [])
             if include_pages:
                 out["pages"] = [
@@ -1350,7 +1309,7 @@ class SearchToolHandler(ToolHandler):
             content_parts = []
             content_parts.append(f"# Search Results for '{query}'\n")
 
-            if _db_mode:
+            if _get_db_mode():
                 content_parts.extend(
                     self._format_db_mode_results(result, limit, include_blocks, include_pages, include_files, excluded_page_names, api)
                 )
@@ -2163,7 +2122,7 @@ class SetBlockPropertiesToolHandler(ToolHandler):
 
     def run_tool(self, args: dict) -> list[TextContent]:
         """Set DB-mode properties on a block."""
-        if not _db_mode:
+        if not _get_db_mode():
             return [TextContent(
                 type="text",
                 text="❌ set_block_properties requires LOGSEQ_DB_MODE=true (only works with Logseq DB-mode graphs)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,3 +316,19 @@ def mock_env_api_key(mock_api_key):
     """Mock the environment variable for API key."""
     with patch.dict("os.environ", {"LOGSEQ_API_TOKEN": mock_api_key}):
         yield mock_api_key
+
+
+@pytest.fixture(autouse=True)
+def _fresh_settings(monkeypatch):
+    """Give every test a valid token and an unfrozen settings cache.
+
+    Settings are resolved lazily via ``get_settings()`` (cached per process);
+    clearing the cache around each test keeps env patches effective and
+    prevents settings state from leaking between tests.
+    """
+    from mcp_logseq import settings
+
+    monkeypatch.setenv("LOGSEQ_API_TOKEN", "test_api_key_12345")
+    settings.get_settings.cache_clear()
+    yield
+    settings.get_settings.cache_clear()

--- a/tests/unit/test_db_properties.py
+++ b/tests/unit/test_db_properties.py
@@ -273,7 +273,7 @@ class TestFormatBlockTreeDbMode:
         }
         db_props = {"uuid-1": {"Status": "Active", "Priority": "High"}}
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, db_props
             )
@@ -292,7 +292,7 @@ class TestFormatBlockTreeDbMode:
         }
         db_props = {"uuid-1": {"Status": "Active"}}
 
-        with patch("mcp_logseq.tools._db_mode", False):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=False):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, db_props
             )
@@ -308,7 +308,7 @@ class TestFormatBlockTreeDbMode:
             "children": [],
         }
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(block, 0, -1, None)
 
         # priority:: high is in content, should not be added again
@@ -323,7 +323,7 @@ class TestFormatBlockTreeDbMode:
             "children": [],
         }
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(block, 0, -1, None)
 
         assert any("status:: active" in l for l in lines)
@@ -349,7 +349,7 @@ class TestFormatBlockTreeDbMode:
             "uuid-child": {"Status": "Done"},
         }
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, db_props
             )
@@ -378,7 +378,7 @@ class TestFeatureFlagIntegration:
 
         handler = GetPageContentToolHandler()
 
-        with patch("mcp_logseq.tools._db_mode", False):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=False):
             result = handler.run_tool({"page_name": "Test"})
 
         # Only 2 API calls (getPage + getPageBlocksTree), no datascript queries
@@ -394,7 +394,7 @@ class TestFeatureFlagIntegration:
 
         handler = SetBlockPropertiesToolHandler()
 
-        with patch("mcp_logseq.tools._db_mode", False):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=False):
             result = handler.run_tool({
                 "block_uuid": "test-uuid",
                 "properties": {"Status": "Active"},
@@ -494,7 +494,7 @@ class TestUuidRefResolution:
         }
         uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "My Page"}
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, None, uuid_map
             )
@@ -511,7 +511,7 @@ class TestUuidRefResolution:
             "children": [],
         }
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, None, None
             )
@@ -535,7 +535,7 @@ class TestUuidRefResolution:
         }
         uuid_map = {"aaaa1111-2222-3333-4444-555566667777": "Resolved Page"}
 
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             lines = GetPageContentToolHandler._format_block_tree(
                 block, 0, -1, None, uuid_map
             )
@@ -657,7 +657,7 @@ class TestGetPageContentResolveRefs:
             status=200)
 
         handler = GetPageContentToolHandler()
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             result = handler.run_tool({"page_name": "Test"})
 
         assert "[[Target Page]]" in result[0].text
@@ -680,7 +680,7 @@ class TestGetPageContentResolveRefs:
         mock_logseq_class.return_value = mock_api
 
         handler = GetPageContentToolHandler()
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             result = handler.run_tool({"page_name": "Test", "resolve_refs": False})
 
         assert "aaaa1111-2222-3333-4444-555566667777" in result[0].text
@@ -703,7 +703,7 @@ class TestGetPageContentResolveRefs:
             status=200)
 
         handler = GetPageContentToolHandler()
-        with patch("mcp_logseq.tools._db_mode", False):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=False):
             result = handler.run_tool({"page_name": "Test"})
 
         assert "[[My Page]]" in result[0].text
@@ -728,7 +728,7 @@ class TestGetPageContentResolveRefs:
             status=200)
 
         handler = GetPageContentToolHandler()
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             result = handler.run_tool({"page_name": "Test", "format": "json"})
 
         parsed = json.loads(result[0].text)

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -333,7 +333,7 @@ def test_set_block_properties_denies():
     # set_block_properties only runs in DB mode; patch _db_mode so the handler
     # reaches the enforcement call rather than returning the DB-mode guard early.
     with _ns(exclude=["finance"]), _api_with_block_page("finance/q3"), \
-            patch("mcp_logseq.tools._db_mode", True):
+            patch("mcp_logseq.tools._get_db_mode", return_value=True):
         with pytest.raises(AccessDenied):
             SetBlockPropertiesToolHandler().run_tool(
                 {"block_uuid": "u7", "properties": {"k": "v"}}
@@ -432,7 +432,7 @@ def test_markdown_search_suppresses_unidentified_blocks_when_excluding_text():
         {"originalName": "work/x", "properties": {}},
     ]
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=False), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "token"})[0].text
         assert "AKIA-leak" not in out
@@ -452,7 +452,7 @@ def test_markdown_search_suppresses_unidentified_blocks_when_excluding_json():
         {"originalName": "work/x", "properties": {}},
     ]
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=False), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "token", "format": "json"})[0].text
         assert "AKIA-leak" not in out
@@ -470,7 +470,7 @@ def test_markdown_search_shows_blocks_when_no_exclusion():
     }
     fake.list_pages.return_value = []
     with _ns(), \
-            patch("mcp_logseq.tools._db_mode", False), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=False), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "block"})[0].text
         assert "ordinary visible block" in out
@@ -705,7 +705,7 @@ def test_db_search_filters_block_from_excluded_namespace_text():
         "uuid-work": "work/x",
     }
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "data"})[0].text
         assert "AKIA-leak" not in out
@@ -731,7 +731,7 @@ def test_db_search_filters_block_from_excluded_namespace_json():
         "uuid-work": "work/x",
     }
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool(
             {"query": "data", "format": "json"}
@@ -766,7 +766,7 @@ def test_db_search_filters_block_from_tag_excluded_page_text():
         _include_namespaces=[],
         _exclude_namespaces=[],
         _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._db_mode", True), \
+    ), patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "note"})[0].text
         assert "AKIA-leak" not in out
@@ -788,7 +788,7 @@ def test_db_search_block_fail_closed_when_unresolvable():
     ]
     fake.resolve_page_uuids.return_value = {}  # cannot resolve
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "x"})[0].text
         assert "AKIA-leak" not in out
@@ -805,7 +805,7 @@ def test_db_search_blocks_pass_when_no_rules():
     }
     fake.list_pages.return_value = []
     with _ns(), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "block"})[0].text
         assert "ordinary visible block" in out
@@ -824,7 +824,7 @@ def test_db_search_fails_closed_when_list_pages_raises_with_rules():
     }
     fake.list_pages.side_effect = RuntimeError("api down")
     with _ns(exclude=["finance"]), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "x"})[0].text
         assert "AKIA-leak" not in out
@@ -842,7 +842,7 @@ def test_search_no_rules_unaffected_by_list_pages():
     }
     fake.list_pages.side_effect = RuntimeError("api down")
     with _ns(), \
-            patch("mcp_logseq.tools._db_mode", True), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "block"})[0].text
         assert "ordinary visible block" in out
@@ -991,7 +991,7 @@ def test_regression_insert_nested_block_denies_private():
 
 def test_regression_set_block_properties_denies_private():
     with _priv(), _api_with_block_page("Private/x"), \
-            patch("mcp_logseq.tools._db_mode", True):
+            patch("mcp_logseq.tools._get_db_mode", return_value=True):
         with pytest.raises(AccessDenied):
             SetBlockPropertiesToolHandler().run_tool(
                 {"block_uuid": "u1", "properties": {"k": "v"}}
@@ -1133,7 +1133,7 @@ def test_delete_block_denies_tag_excluded_owning_page():
 
 def test_set_block_properties_denies_tag_excluded_owning_page():
     with _tags_excluded(), _tagged_page_api(), \
-            patch("mcp_logseq.tools._db_mode", True):
+            patch("mcp_logseq.tools._get_db_mode", return_value=True):
         with pytest.raises(AccessDenied):
             SetBlockPropertiesToolHandler().run_tool(
                 {"block_uuid": "u1", "properties": {"k": "v"}}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,109 @@
+"""Tests for mcp_logseq.settings — lazy, validated configuration.
+
+Covers the A1 refactor: importing the package must have no env side effects;
+all env reading and validation happens in ``load_settings()`` /
+``get_settings()`` at startup, not at import time.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from mcp_logseq import settings
+
+_ENV_VARS = (
+    "LOGSEQ_API_TOKEN",
+    "LOGSEQ_API_URL",
+    "LOGSEQ_VERIFY_SSL",
+    "LOGSEQ_API_CONNECT_TIMEOUT",
+    "LOGSEQ_API_READ_TIMEOUT",
+    "LOGSEQ_DB_MODE",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip all settings-related env vars and reset the settings cache."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    settings.get_settings.cache_clear()
+    yield monkeypatch
+    settings.get_settings.cache_clear()
+
+
+class TestImportHasNoSideEffects:
+    def test_import_without_token_succeeds(self):
+        """Importing tools/server must not require LOGSEQ_API_TOKEN (A1)."""
+        env = {k: v for k, v in os.environ.items() if k not in _ENV_VARS}
+        result = subprocess.run(
+            [sys.executable, "-c", "import mcp_logseq.tools, mcp_logseq.server"],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestLoadSettings:
+    def test_missing_token_raises(self, clean_env):
+        with pytest.raises(ValueError, match="LOGSEQ_API_TOKEN"):
+            settings.load_settings()
+
+    def test_defaults(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        s = settings.load_settings()
+        assert s.api_key == "tok"
+        assert s.protocol == "http"
+        assert s.host == "localhost"
+        assert s.port == 12315
+        assert s.verify_ssl is False  # plain http → no TLS verification
+        assert s.timeout == (3, 6)
+        assert s.db_mode is False
+
+    def test_api_url_parsed(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        clean_env.setenv("LOGSEQ_API_URL", "https://logseq.example.com:8443")
+        s = settings.load_settings()
+        assert s.protocol == "https"
+        assert s.host == "logseq.example.com"
+        assert s.port == 8443
+        assert s.verify_ssl is True  # https → verify by default
+
+    def test_verify_ssl_env_overrides_protocol_default(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        clean_env.setenv("LOGSEQ_API_URL", "https://logseq.example.com:8443")
+        clean_env.setenv("LOGSEQ_VERIFY_SSL", "false")
+        assert settings.load_settings().verify_ssl is False
+
+    def test_db_mode_env(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        clean_env.setenv("LOGSEQ_DB_MODE", "true")
+        assert settings.load_settings().db_mode is True
+
+    def test_timeout_overrides(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        clean_env.setenv("LOGSEQ_API_CONNECT_TIMEOUT", "2.5")
+        clean_env.setenv("LOGSEQ_API_READ_TIMEOUT", "15")
+        assert settings.load_settings().timeout == (2.5, 15.0)
+
+    def test_invalid_timeout_falls_back_to_default(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok")
+        clean_env.setenv("LOGSEQ_API_READ_TIMEOUT", "not-a-number")
+        assert settings.load_settings().timeout == (3, 6)
+
+
+class TestGetSettingsCache:
+    def test_cached_across_env_changes(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok-1")
+        first = settings.get_settings()
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok-2")
+        assert settings.get_settings() is first
+
+    def test_cache_clear_picks_up_new_env(self, clean_env):
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok-1")
+        settings.get_settings()
+        clean_env.setenv("LOGSEQ_API_TOKEN", "tok-2")
+        settings.get_settings.cache_clear()
+        assert settings.get_settings().api_key == "tok-2"

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -1,4 +1,3 @@
-import importlib
 import json
 
 import pytest
@@ -26,109 +25,24 @@ from mcp_logseq.tools import (
 
 
 class TestToolConfiguration:
-    """Test cases for module-level tool configuration."""
-
-    @patch.dict("os.environ", {}, clear=True)
-    def test_parse_positive_float_env_uses_default(self):
-        assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
+    """Settings-driven tool configuration (see tests/unit/test_settings.py
+    for the full env-var wiring coverage)."""
 
     @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "60"})
-    def test_parse_positive_float_env_uses_override(self):
-        assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 60
-
-    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "2.5"})
-    def test_parse_positive_float_env_accepts_float_override(self):
-        assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 2.5
-
-    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "0"})
-    def test_parse_positive_float_env_non_positive_falls_back_to_default(self):
-        with patch.object(tools.logger, "warning") as mock_warning:
-            assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
-        mock_warning.assert_called_once()
-
-    @patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": "fast"})
-    def test_parse_positive_float_env_invalid_falls_back_to_default(self):
-        with patch.object(tools.logger, "warning") as mock_warning:
-            assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
-        mock_warning.assert_called_once()
-
-    @pytest.mark.parametrize("raw_value", ["nan", "inf", "-inf"])
-    def test_parse_positive_float_env_non_finite_falls_back_to_default(self, raw_value):
-        with patch.dict("os.environ", {"LOGSEQ_API_READ_TIMEOUT": raw_value}):
-            with patch.object(tools.logger, "warning") as mock_warning:
-                assert tools._parse_positive_float_env("LOGSEQ_API_READ_TIMEOUT", 6) == 6
-            mock_warning.assert_called_once()
-
     @patch("mcp_logseq.tools.logseq.LogSeq")
     def test_make_api_passes_configured_timeout(self, mock_logseq_class):
-        original_timeout = tools._api_timeout
-        try:
-            tools._api_timeout = (3, 60)
+        tools._make_api()
 
-            tools._make_api()
+        assert mock_logseq_class.call_args.kwargs["timeout"] == (3, 60.0)
 
-            assert mock_logseq_class.call_args.kwargs["timeout"] == (3, 60)
-        finally:
-            tools._api_timeout = original_timeout
-
-
-class TestTimeoutEnvVars:
-    """Module-level timeout globals are wired from env vars at import time.
-
-    These reload the tools module under a patched environment to exercise the
-    actual ``_api_connect_timeout`` / ``_api_read_timeout`` / ``_api_timeout``
-    wiring (the unit tests above only call ``_parse_positive_float_env``
-    directly). The autouse fixture restores a clean module afterwards so the
-    reload does not leak timeout state into other tests.
-    """
-
-    @pytest.fixture(autouse=True)
-    def _restore_tools_module(self):
-        yield
-        with patch.dict("os.environ", {"LOGSEQ_API_TOKEN": "test_token"}, clear=True):
-            importlib.reload(tools)
-
-    @staticmethod
-    def _reload(env):
-        with patch.dict(
-            "os.environ", {"LOGSEQ_API_TOKEN": "test_token", **env}, clear=True
-        ):
-            importlib.reload(tools)
-        return tools
-
-    def test_module_level_defaults(self):
-        reloaded = self._reload({})
-        assert reloaded._api_connect_timeout == 3
-        assert reloaded._api_read_timeout == 6
-        assert reloaded._api_timeout == (3, 6)
-
-    def test_connect_timeout_override(self):
-        reloaded = self._reload({"LOGSEQ_API_CONNECT_TIMEOUT": "10"})
-        assert reloaded._api_connect_timeout == 10.0
-        assert reloaded._api_timeout == (10.0, 6)
-
-    def test_read_timeout_override(self):
-        reloaded = self._reload({"LOGSEQ_API_READ_TIMEOUT": "30"})
-        assert reloaded._api_read_timeout == 30.0
-        assert reloaded._api_timeout == (3, 30.0)
-
-    def test_float_overrides(self):
-        reloaded = self._reload(
-            {"LOGSEQ_API_CONNECT_TIMEOUT": "2.5", "LOGSEQ_API_READ_TIMEOUT": "15.0"}
-        )
-        assert reloaded._api_timeout == (2.5, 15.0)
-
-    def test_invalid_override_falls_back_to_default(self):
-        reloaded = self._reload({"LOGSEQ_API_CONNECT_TIMEOUT": "not-a-number"})
-        assert reloaded._api_connect_timeout == 3
-        assert reloaded._api_timeout == (3, 6)
-
+    @patch.dict(
+        "os.environ",
+        {"LOGSEQ_API_CONNECT_TIMEOUT": "2.5", "LOGSEQ_API_READ_TIMEOUT": "15.0"},
+    )
     @patch("mcp_logseq.tools.logseq.LogSeq")
     def test_make_api_passes_env_timeouts_end_to_end(self, mock_logseq_class):
-        reloaded = self._reload(
-            {"LOGSEQ_API_CONNECT_TIMEOUT": "2.5", "LOGSEQ_API_READ_TIMEOUT": "15.0"}
-        )
-        reloaded._make_api()
+        tools._make_api()
+
         assert mock_logseq_class.call_args.kwargs["timeout"] == (2.5, 15.0)
 
 
@@ -1020,7 +934,7 @@ class TestSearchToolHandler:
         mock_logseq_class.return_value = mock_api
 
         handler = SearchToolHandler()
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             result = handler.run_tool({"query": "Claude Code sessie"})
 
         text = result[0].text
@@ -1074,7 +988,7 @@ class TestSearchToolHandler:
         mock_logseq_class.return_value = mock_api
 
         handler = SearchToolHandler()
-        with patch("mcp_logseq.tools._db_mode", True):
+        with patch("mcp_logseq.tools._get_db_mode", return_value=True):
             result = handler.run_tool({"query": "match", "format": "json"})
 
         data = json.loads(result[0].text)


### PR DESCRIPTION
This implements item A1 from the architecture review: importing `mcp_logseq.tools` (or `server`) no longer reads the environment or raises when `LOGSEQ_API_TOKEN` is missing.

All env parsing and validation now lives in a new `settings.py` module: a frozen `Settings` dataclass built by `load_settings()` and cached by `get_settings()`. Validation happens once at startup (fail fast in `server.main`), not at import time.

**Changes**
- `tools.py`: removed the module level env block. `_make_api()` and the new `_get_db_mode()` read from `get_settings()`
- `server.py`: dropped the duplicated token validation, now validates via `get_settings()` at startup
- Tests: the suite no longer needs a token to collect or run. A conftest autouse fixture provides a token and clears the settings cache per test. The `importlib.reload` based timeout wiring tests are replaced by direct `load_settings()` tests in `test_settings.py`

**Why it matters**
- `pytest` on main currently fails at collection without `LOGSEQ_API_TOKEN` set, because importing `tools` raises. On this branch the suite runs clean without any env setup
- Import order no longer matters for the sync writer and other consumers that don't need the API token

Tests: 603 passed (main: 606, minus 13 removed reload based tests, plus 10 new settings tests).