### PR TITLE
refactor: extract ACL config and enforcement into access.py (A6, A7)

### DIFF
--- a/src/mcp_logseq/access.py
+++ b/src/mcp_logseq/access.py
@@ -1,0 +1,177 @@
+"""Access control (ACL) configuration and enforcement.
+
+Owns the resolved exclude-tag / namespace lists and every predicate and
+enforcement helper built on them. Shared by the query-time tool layer
+(``tools.py``) and the vector search layer (``vector/index.py``), so neither
+has to reach into the other's internals.
+
+Like ``settings.py``, loading is lazy: importing this module has no side
+effects. The ACL lists are read from the environment / config file on first
+use via ``get_access_config()`` and cached for the life of the process.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from dataclasses import dataclass, field
+
+from .config import csv_config_value, read_config_file
+from .namespace import is_namespace_blocked
+
+logger = logging.getLogger("mcp-logseq")
+
+
+@dataclass(frozen=True)
+class AccessConfig:
+    """Resolved ACL lists (exclude tags plus namespace allow/deny lists)."""
+
+    exclude_tags: list[str] = field(default_factory=list)
+    include_namespaces: list[str] = field(default_factory=list)
+    exclude_namespaces: list[str] = field(default_factory=list)
+
+    @property
+    def has_rules(self) -> bool:
+        return bool(
+            self.exclude_tags or self.include_namespaces or self.exclude_namespaces
+        )
+
+
+def load_access_config() -> AccessConfig:
+    """Resolve the ACL lists from env vars / the config file.
+
+    Parses the config file once for all three lists (env vars take priority
+    per list). Never raises.
+    """
+    raw = read_config_file()
+    return AccessConfig(
+        exclude_tags=csv_config_value(raw, "LOGSEQ_EXCLUDE_TAGS", "exclude_tags"),
+        include_namespaces=csv_config_value(
+            raw, "LOGSEQ_INCLUDE_NAMESPACES", "include_namespaces"
+        ),
+        exclude_namespaces=csv_config_value(
+            raw, "LOGSEQ_EXCLUDE_NAMESPACES", "exclude_namespaces"
+        ),
+    )
+
+
+@functools.cache
+def get_access_config() -> AccessConfig:
+    """Return the process-wide ``AccessConfig``, loading it on first use.
+
+    Cached for the life of the process; call ``get_access_config.cache_clear()``
+    (tests) to force a reload from the environment.
+    """
+    return load_access_config()
+
+
+class AccessDenied(RuntimeError):
+    """Raised when a tool is blocked from accessing a restricted page."""
+
+
+def extract_tags(properties: dict) -> list[str]:
+    """Extract tags from a Logseq properties dict (list or comma-string form)."""
+    raw = properties.get("tags", [])
+    if isinstance(raw, str):
+        return [t.strip() for t in raw.split(",") if t.strip()]
+    elif isinstance(raw, list):
+        return [str(t).strip() for t in raw if str(t).strip()]
+    return []
+
+
+def is_page_excluded(page: dict, exclude_tags: list[str]) -> bool:
+    """Return True if the page has any tag in exclude_tags."""
+    if not exclude_tags:
+        return False
+    props = page.get("properties") or {}
+    return any(t in exclude_tags for t in extract_tags(props))
+
+
+def is_page_blocked(page: dict | None, page_name: str) -> bool:
+    """Combined tag OR namespace block check (used for result filtering)."""
+    acl = get_access_config()
+    if page and is_page_excluded(page, acl.exclude_tags):
+        return True
+    return is_namespace_blocked(
+        page_name, acl.include_namespaces, acl.exclude_namespaces
+    )
+
+
+def enforce_namespace_access(page_name: str) -> None:
+    """Raise AccessDenied if page_name is blocked by namespace rules.
+
+    Name-based only (no tag check — that needs fetched page properties).
+    """
+    acl = get_access_config()
+    if is_namespace_blocked(page_name, acl.include_namespaces, acl.exclude_namespaces):
+        raise AccessDenied(
+            f"Access denied: page '{page_name}' is restricted "
+            f"and cannot be accessed by this assistant."
+        )
+
+
+def enforce_block_namespace_access(api, block_uuid: str) -> None:
+    """Resolve a block's owning page and enforce namespace rules.
+
+    Fail-closed: when namespace rules are configured but the page cannot be
+    resolved, access is denied. When no namespace rules exist, this is a no-op.
+    """
+    acl = get_access_config()
+    if not acl.include_namespaces and not acl.exclude_namespaces:
+        return
+    page_name = api.get_block_page_name(block_uuid)
+    if page_name is None:
+        raise AccessDenied(
+            f"Access denied: cannot verify the namespace of block '{block_uuid}'."
+        )
+    enforce_namespace_access(page_name)
+
+
+def enforce_page_tag_access(api, page_name: str) -> None:
+    """Raise AccessDenied if an EXISTING page carries an excluded tag.
+
+    Complements the name-based namespace check on write handlers: namespace
+    rules can be evaluated from the name alone, but tag exclusion requires the
+    page's properties, so this fetches the page. A no-op when no exclude tags
+    are configured.
+
+    Two cases are NOT excluded — but only the first is also a quiet pass:
+    - ``get_page_content`` returns None/empty: the page does not exist (or has
+      no properties) and therefore carries no tags. Treated as NOT excluded so
+      ``update_page`` keeps working for brand-new pages.
+    - ``get_page_content`` RAISES: with exclude tags configured we cannot verify
+      the page's tags, so we must NOT silently proceed with the write. The error
+      is allowed to propagate (no try/except) so the calling write handler
+      aborts the mutation via its normal error path (fail-closed). It is not an
+      AccessDenied, so it isn't mislabeled — it just isn't swallowed.
+    """
+    acl = get_access_config()
+    if not acl.exclude_tags:
+        return
+    # No try/except by design: when exclude tags are configured, a fetch error
+    # must abort the write rather than fail open. A non-existent page returns
+    # None and falls through as not-excluded.
+    result = api.get_page_content(page_name)
+    if result and is_page_excluded(result.get("page", {}), acl.exclude_tags):
+        raise AccessDenied(
+            f"Access denied: page '{page_name}' is restricted "
+            f"and cannot be accessed by this assistant."
+        )
+
+
+def enforce_block_tag_access(api, block_uuid: str) -> None:
+    """Resolve a block's owning page and enforce tag exclusion on it.
+
+    A no-op when no exclude tags are configured. When tags ARE configured but
+    the owning page cannot be resolved, access is denied (fail-closed), mirroring
+    ``enforce_block_namespace_access``.
+    """
+    acl = get_access_config()
+    if not acl.exclude_tags:
+        return
+    page_name = api.get_block_page_name(block_uuid)
+    if page_name is None:
+        raise AccessDenied(
+            f"Access denied: cannot verify the owning page of block '{block_uuid}'."
+        )
+    enforce_page_tag_access(api, page_name)

--- a/src/mcp_logseq/config.py
+++ b/src/mcp_logseq/config.py
@@ -70,11 +70,12 @@ class VectorConfig:
     watch_debounce_ms: int = 5000
 
 
-def load_vector_config() -> VectorConfig | None:
-    """
-    Load vector config from LOGSEQ_CONFIG_FILE.
-    Returns None if env var is not set, file is missing, or vector.enabled is not true.
-    Never raises — logs warnings on issues.
+def read_config_file() -> dict | None:
+    """Read and parse the JSON file pointed to by LOGSEQ_CONFIG_FILE.
+
+    Single choke point for config-file IO: returns None if the env var is not
+    set, the file is missing, or it cannot be parsed. Never raises — logs
+    warnings on issues.
     """
     config_path = os.getenv("LOGSEQ_CONFIG_FILE")
     if not config_path:
@@ -87,9 +88,20 @@ def load_vector_config() -> VectorConfig | None:
 
     try:
         with open(config_path) as f:
-            raw = json.load(f)
+            return json.load(f)
     except Exception as e:
         logger.warning(f"Failed to parse config file {config_path}: {e}")
+        return None
+
+
+def load_vector_config() -> VectorConfig | None:
+    """
+    Load vector config from LOGSEQ_CONFIG_FILE.
+    Returns None if env var is not set, file is missing, or vector.enabled is not true.
+    Never raises — logs warnings on issues.
+    """
+    raw = read_config_file()
+    if raw is None:
         return None
 
     vector_raw = raw.get("vector")
@@ -175,12 +187,15 @@ def load_vector_config() -> VectorConfig | None:
     )
 
 
-def _load_csv_config(env_var: str, config_key: str) -> list[str]:
-    """Load a comma/list config value from an env var or the config file root.
+def csv_config_value(raw: dict | None, env_var: str, config_key: str) -> list[str]:
+    """Resolve a comma/list config value from an env var or a parsed config dict.
 
     Priority: env var > config file root key > [] (no value).
     env var: comma-separated string. config file: list or comma-separated string.
     Strips whitespace and drops empties. Never raises.
+
+    ``raw`` is the already-parsed config file (``read_config_file()``), so
+    callers resolving several keys parse the file only once.
     """
     env_val = os.getenv(env_var, "").strip()
     if env_val:
@@ -189,17 +204,7 @@ def _load_csv_config(env_var: str, config_key: str) -> list[str]:
             logger.info(f"Loaded {len(items)} entries from {env_var}")
             return items
 
-    config_path = os.getenv("LOGSEQ_CONFIG_FILE")
-    if not config_path:
-        return []
-    config_path = os.path.expanduser(config_path)
-    if not os.path.exists(config_path):
-        return []
-    try:
-        with open(config_path) as f:
-            raw = json.load(f)
-    except Exception as e:
-        logger.warning(f"Failed to parse config file for {config_key} {config_path}: {e}")
+    if raw is None:
         return []
 
     raw_val = raw.get(config_key, [])
@@ -216,14 +221,14 @@ def _load_csv_config(env_var: str, config_key: str) -> list[str]:
 
 def load_exclude_tags() -> list[str]:
     """Load top-level exclude_tags. Priority: env var > config file > []."""
-    return _load_csv_config("LOGSEQ_EXCLUDE_TAGS", "exclude_tags")
+    return csv_config_value(read_config_file(), "LOGSEQ_EXCLUDE_TAGS", "exclude_tags")
 
 
 def load_include_namespaces() -> list[str]:
     """Load allow-list namespaces. Priority: env var > config file > []."""
-    return _load_csv_config("LOGSEQ_INCLUDE_NAMESPACES", "include_namespaces")
+    return csv_config_value(read_config_file(), "LOGSEQ_INCLUDE_NAMESPACES", "include_namespaces")
 
 
 def load_exclude_namespaces() -> list[str]:
     """Load deny-list namespaces. Priority: env var > config file > []."""
-    return _load_csv_config("LOGSEQ_EXCLUDE_NAMESPACES", "exclude_namespaces")
+    return csv_config_value(read_config_file(), "LOGSEQ_EXCLUDE_NAMESPACES", "exclude_namespaces")

--- a/src/mcp_logseq/namespace.py
+++ b/src/mcp_logseq/namespace.py
@@ -1,9 +1,8 @@
 """Pure, side-effect-free namespace matching.
 
-Shared by the query-time ACL layer (``tools.py``) and the index-time vector
+Shared by the query-time ACL layer (``access.py``) and the index-time vector
 indexer (``vector/chunker.py``). Kept dependency-free so the sync writer, which
-runs without ``LOGSEQ_API_TOKEN``, can import it without triggering ``tools.py``'s
-import-time environment checks.
+runs without ``LOGSEQ_API_TOKEN``, can import it in isolation.
 """
 
 from __future__ import annotations

--- a/src/mcp_logseq/server.py
+++ b/src/mcp_logseq/server.py
@@ -101,10 +101,11 @@ def _register_all_tool_handlers(handlers: dict, read_only: bool = False) -> None
     # Conditional vector tool registration — only when LOGSEQ_CONFIG_FILE is set
     # and vector.enabled is true in the config file
     try:
-        from .config import load_vector_config, load_exclude_tags
+        from .access import get_access_config
+        from .config import load_vector_config
         vector_config = load_vector_config()
         # Merge top-level exclude_tags into vector config (additive union)
-        top_level_exclude = load_exclude_tags()
+        top_level_exclude = get_access_config().exclude_tags
         if vector_config and top_level_exclude:
             merged = list(dict.fromkeys(top_level_exclude + vector_config.exclude_tags))
             vector_config.exclude_tags = merged

--- a/src/mcp_logseq/tools.py
+++ b/src/mcp_logseq/tools.py
@@ -2,18 +2,24 @@ import json
 import re
 import logging
 from typing import Any
+from . import access
 from . import logseq
 from . import parser
-from .config import load_exclude_tags, load_include_namespaces, load_exclude_namespaces
+from .access import (
+    AccessDenied,
+    extract_tags as _extract_tags,
+    is_page_excluded as _is_page_excluded,
+    is_page_blocked as _is_page_blocked,
+    enforce_namespace_access as _enforce_namespace_access,
+    enforce_block_namespace_access as _enforce_block_namespace_access,
+    enforce_page_tag_access as _enforce_page_tag_access,
+    enforce_block_tag_access as _enforce_block_tag_access,
+)
 from .namespace import is_namespace_blocked as _is_namespace_blocked
 from .settings import get_settings
 from mcp.types import Tool, TextContent
 
 logger = logging.getLogger("mcp-logseq")
-
-_exclude_tags: list[str] = load_exclude_tags()
-_include_namespaces: list[str] = load_include_namespaces()
-_exclude_namespaces: list[str] = load_exclude_namespaces()
 
 
 def _get_db_mode() -> bool:
@@ -59,111 +65,6 @@ def _resolve_block_refs(content: str, uuid_map: dict[str, str]) -> str:
         return match.group(0)  # Keep original if not resolved
 
     return _UUID_REF_PATTERN.sub(_replace, content)
-
-
-def _extract_tags(properties: dict) -> list[str]:
-    """Extract tags from a Logseq properties dict (list or comma-string form)."""
-    raw = properties.get("tags", [])
-    if isinstance(raw, str):
-        return [t.strip() for t in raw.split(",") if t.strip()]
-    elif isinstance(raw, list):
-        return [str(t).strip() for t in raw if str(t).strip()]
-    return []
-
-
-def _is_page_excluded(page: dict, exclude_tags: list[str]) -> bool:
-    """Return True if the page has any tag in exclude_tags."""
-    if not exclude_tags:
-        return False
-    props = page.get("properties") or {}
-    return any(t in exclude_tags for t in _extract_tags(props))
-
-
-class AccessDenied(RuntimeError):
-    """Raised when a tool is blocked from accessing a restricted page."""
-
-
-def _is_page_blocked(page: dict | None, page_name: str) -> bool:
-    """Combined tag OR namespace block check (used for result filtering)."""
-    if page and _is_page_excluded(page, _exclude_tags):
-        return True
-    return _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces)
-
-
-def _enforce_namespace_access(page_name: str) -> None:
-    """Raise AccessDenied if page_name is blocked by namespace rules.
-
-    Name-based only (no tag check — that needs fetched page properties).
-    """
-    if _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces):
-        raise AccessDenied(
-            f"Access denied: page '{page_name}' is restricted "
-            f"and cannot be accessed by this assistant."
-        )
-
-
-def _enforce_block_namespace_access(api, block_uuid: str) -> None:
-    """Resolve a block's owning page and enforce namespace rules.
-
-    Fail-closed: when namespace rules are configured but the page cannot be
-    resolved, access is denied. When no namespace rules exist, this is a no-op.
-    """
-    if not _include_namespaces and not _exclude_namespaces:
-        return
-    page_name = api.get_block_page_name(block_uuid)
-    if page_name is None:
-        raise AccessDenied(
-            f"Access denied: cannot verify the namespace of block '{block_uuid}'."
-        )
-    _enforce_namespace_access(page_name)
-
-
-def _enforce_page_tag_access(api, page_name: str) -> None:
-    """Raise AccessDenied if an EXISTING page carries an excluded tag.
-
-    Complements the name-based namespace check on write handlers: namespace
-    rules can be evaluated from the name alone, but tag exclusion requires the
-    page's properties, so this fetches the page. A no-op when no exclude tags
-    are configured.
-
-    Two cases are NOT excluded — but only the first is also a quiet pass:
-    - ``get_page_content`` returns None/empty: the page does not exist (or has
-      no properties) and therefore carries no tags. Treated as NOT excluded so
-      ``update_page`` keeps working for brand-new pages.
-    - ``get_page_content`` RAISES: with exclude tags configured we cannot verify
-      the page's tags, so we must NOT silently proceed with the write. The error
-      is allowed to propagate (no try/except) so the calling write handler
-      aborts the mutation via its normal error path (fail-closed). It is not an
-      AccessDenied, so it isn't mislabeled — it just isn't swallowed.
-    """
-    if not _exclude_tags:
-        return
-    # No try/except by design: when exclude tags are configured, a fetch error
-    # must abort the write rather than fail open. A non-existent page returns
-    # None and falls through as not-excluded.
-    result = api.get_page_content(page_name)
-    if result and _is_page_excluded(result.get("page", {}), _exclude_tags):
-        raise AccessDenied(
-            f"Access denied: page '{page_name}' is restricted "
-            f"and cannot be accessed by this assistant."
-        )
-
-
-def _enforce_block_tag_access(api, block_uuid: str) -> None:
-    """Resolve a block's owning page and enforce tag exclusion on it.
-
-    A no-op when no exclude tags are configured. When tags ARE configured but
-    the owning page cannot be resolved, access is denied (fail-closed), mirroring
-    ``_enforce_block_namespace_access``.
-    """
-    if not _exclude_tags:
-        return
-    page_name = api.get_block_page_name(block_uuid)
-    if page_name is None:
-        raise AccessDenied(
-            f"Access denied: cannot verify the owning page of block '{block_uuid}'."
-        )
-    _enforce_page_tag_access(api, page_name)
 
 
 class ToolHandler:
@@ -1295,8 +1196,9 @@ class SearchToolHandler(ToolHandler):
                 ]
 
             # Build excluded page name set (one extra API call only when needed)
+            acl = access.get_access_config()
             excluded_page_names = self._build_excluded_page_names(
-                api, _exclude_tags, _exclude_namespaces, _include_namespaces
+                api, acl.exclude_tags, acl.exclude_namespaces, acl.include_namespaces
             )
 
             if args.get("format") == "json":
@@ -1433,16 +1335,17 @@ class QueryToolHandler(ToolHandler):
 
     def _page_name_blocked(self, page_name: str, api) -> bool:
         """Tag OR namespace block decision for an already-resolved page name."""
-        if _is_namespace_blocked(page_name, _include_namespaces, _exclude_namespaces):
+        acl = access.get_access_config()
+        if _is_namespace_blocked(page_name, acl.include_namespaces, acl.exclude_namespaces):
             return True
-        if _exclude_tags:
+        if acl.exclude_tags:
             # Tag exclusion needs the page's properties; fetch the owning page
             # and inspect its tags. Fail-closed if it cannot be fetched.
             try:
                 page = api.get_page_content(page_name)
             except Exception:
                 return True
-            if page and _is_page_excluded(page.get("page", {}), _exclude_tags):
+            if page and _is_page_excluded(page.get("page", {}), acl.exclude_tags):
                 return True
         return False
 
@@ -1504,7 +1407,7 @@ class QueryToolHandler(ToolHandler):
             # are checkable too — block filtering must run whenever ANY rule is
             # active (tag-only profiles included). Resolution is fail-closed
             # (unresolvable owning page => dropped).
-            if _exclude_tags or _include_namespaces or _exclude_namespaces:
+            if access.get_access_config().has_rules:
                 filtered = []
                 # Per-request memo so blocks sharing an owning page only trigger
                 # one tag/namespace resolution + fetch.
@@ -1636,7 +1539,7 @@ class FindPagesByPropertyToolHandler(ToolHandler):
                 return [TextContent(type="text", text=msg)]
 
             # Security: drop pages blocked by tag OR namespace before limiting
-            if _exclude_tags or _include_namespaces or _exclude_namespaces:
+            if access.get_access_config().has_rules:
                 kept = []
                 for item in result:
                     if isinstance(item, dict):

--- a/src/mcp_logseq/vector/index.py
+++ b/src/mcp_logseq/vector/index.py
@@ -19,14 +19,10 @@ from typing import Protocol, TypeVar
 
 from mcp.types import TextContent, Tool
 
+from mcp_logseq import access
 from mcp_logseq.config import VectorConfig
-from mcp_logseq.tools import (
-    ToolHandler,
-    _is_namespace_blocked,
-    _include_namespaces,
-    _exclude_namespaces,
-    _exclude_tags,
-)
+from mcp_logseq.namespace import is_namespace_blocked
+from mcp_logseq.tools import ToolHandler
 from mcp_logseq.vector.db import VectorDB
 from mcp_logseq.vector.embedder import create_embedder
 from mcp_logseq.vector.state import StateManager
@@ -67,7 +63,7 @@ def _filter_results_by_namespace(
     """Drop vector search results whose page is blocked by namespace rules."""
     if not include and not exclude:
         return list(results)
-    return [r for r in results if not _is_namespace_blocked(r.page, include, exclude)]
+    return [r for r in results if not is_namespace_blocked(r.page, include, exclude)]
 
 
 def _filter_results_by_tags(
@@ -267,10 +263,11 @@ class VectorSearchToolHandler(ToolHandler):
         finally:
             db.close()
 
+        acl = access.get_access_config()
         results = _filter_results_by_namespace(
-            results, _include_namespaces, _exclude_namespaces
+            results, acl.include_namespaces, acl.exclude_namespaces
         )
-        results = _filter_results_by_tags(results, _exclude_tags)
+        results = _filter_results_by_tags(results, acl.exclude_tags)
         output = output_prefix + _format_search_results(results)
         return [TextContent(type="text", text=output)]
 

--- a/tests/integration/test_http_serving.py
+++ b/tests/integration/test_http_serving.py
@@ -19,7 +19,7 @@ Two layers are exercised:
   protocol rather than this project's security contract. Instead we drive the
   EXACT handler registry the served app exposes — ``build_app(read_only=...)``
   returns ``(server, handlers)`` where ``handlers`` is the same dict the app's
-  ``call_tool`` closure dispatches to — with the profile's ACL globals active.
+  ``call_tool`` closure dispatches to — with the profile's ACL config active.
   This proves denied-namespace content never surfaces and that the read-only
   app's tool set omits genuine write tools, end-to-end through the served app
   object, without re-testing the SDK.
@@ -30,25 +30,23 @@ from unittest.mock import Mock, patch
 import pytest
 from starlette.testclient import TestClient
 
+from mcp_logseq.access import AccessConfig, AccessDenied
 from mcp_logseq.transport.http import create_asgi_app
 from mcp_logseq.server import build_app, _WRITE_TOOL_NAMES
-from mcp_logseq.tools import AccessDenied
 
 
 TOKEN = "journal-profile-token"
 
 
 def _journal_only_profile():
-    """Activate the Journal-only ACL profile on the served handlers' globals.
+    """Activate the Journal-only ACL profile on the served handlers' config.
 
     ``include=['Journal']`` is a strict allow-list: only ``Journal`` and its
     children are reachable; ``Work/*`` (and every other namespace) is denied.
     """
-    return patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=["Journal"],
-        _exclude_namespaces=[],
-        _exclude_tags=[],
+    return patch(
+        "mcp_logseq.access.get_access_config",
+        return_value=AccessConfig(include_namespaces=["Journal"]),
     )
 
 

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -1,0 +1,122 @@
+"""Tests for mcp_logseq.access — lazy, cached ACL configuration.
+
+Covers the A6/A7 refactor: the ACL lists live in a dedicated module shared by
+``tools.py`` and ``vector/index.py``; loading is lazy (no import-time side
+effects) and parses the config file only once for all three lists.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from mcp_logseq import access
+from mcp_logseq.access import AccessConfig
+
+_ENV_VARS = (
+    "LOGSEQ_EXCLUDE_TAGS",
+    "LOGSEQ_INCLUDE_NAMESPACES",
+    "LOGSEQ_EXCLUDE_NAMESPACES",
+    "LOGSEQ_CONFIG_FILE",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Strip all ACL-related env vars and reset the access-config cache."""
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    access.get_access_config.cache_clear()
+    yield monkeypatch
+    access.get_access_config.cache_clear()
+
+
+class TestLoadAccessConfig:
+    def test_defaults_to_empty_lists(self, clean_env):
+        acl = access.load_access_config()
+        assert acl.exclude_tags == []
+        assert acl.include_namespaces == []
+        assert acl.exclude_namespaces == []
+        assert acl.has_rules is False
+
+    def test_reads_all_lists_from_env(self, clean_env):
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "private,secret")
+        clean_env.setenv("LOGSEQ_INCLUDE_NAMESPACES", "work")
+        clean_env.setenv("LOGSEQ_EXCLUDE_NAMESPACES", "work/secret")
+        acl = access.load_access_config()
+        assert acl.exclude_tags == ["private", "secret"]
+        assert acl.include_namespaces == ["work"]
+        assert acl.exclude_namespaces == ["work/secret"]
+        assert acl.has_rules is True
+
+    def test_reads_all_lists_from_config_file(self, clean_env, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "exclude_tags": ["private"],
+                    "include_namespaces": ["work"],
+                    "exclude_namespaces": ["work/secret"],
+                }
+            )
+        )
+        clean_env.setenv("LOGSEQ_CONFIG_FILE", str(path))
+        acl = access.load_access_config()
+        assert acl.exclude_tags == ["private"]
+        assert acl.include_namespaces == ["work"]
+        assert acl.exclude_namespaces == ["work/secret"]
+
+    def test_env_var_overrides_config_file_per_list(self, clean_env, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text(
+            json.dumps(
+                {"exclude_tags": ["from-file"], "include_namespaces": ["file-ns"]}
+            )
+        )
+        clean_env.setenv("LOGSEQ_CONFIG_FILE", str(path))
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "from-env")
+        acl = access.load_access_config()
+        assert acl.exclude_tags == ["from-env"]
+        assert acl.include_namespaces == ["file-ns"]
+
+    def test_parses_config_file_once_for_all_lists(self, clean_env, tmp_path):
+        """A7: one load_access_config() call must read the file exactly once."""
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps({"exclude_tags": ["private"]}))
+        clean_env.setenv("LOGSEQ_CONFIG_FILE", str(path))
+        with patch(
+            "mcp_logseq.access.read_config_file",
+            wraps=access.read_config_file,
+        ) as reader:
+            access.load_access_config()
+        assert reader.call_count == 1
+
+
+class TestGetAccessConfig:
+    def test_cached_across_calls(self, clean_env):
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "private")
+        first = access.get_access_config()
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "changed")
+        assert access.get_access_config() is first
+        assert access.get_access_config().exclude_tags == ["private"]
+
+    def test_cache_clear_reloads(self, clean_env):
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "private")
+        assert access.get_access_config().exclude_tags == ["private"]
+        clean_env.setenv("LOGSEQ_EXCLUDE_TAGS", "changed")
+        access.get_access_config.cache_clear()
+        assert access.get_access_config().exclude_tags == ["changed"]
+
+
+class TestHasRules:
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            ({}, False),
+            ({"exclude_tags": ["private"]}, True),
+            ({"include_namespaces": ["work"]}, True),
+            ({"exclude_namespaces": ["work/secret"]}, True),
+        ],
+    )
+    def test_has_rules(self, kwargs, expected):
+        assert AccessConfig(**kwargs).has_rules is expected

--- a/tests/unit/test_exclude_tags.py
+++ b/tests/unit/test_exclude_tags.py
@@ -14,6 +14,7 @@ import pytest
 from unittest.mock import patch, Mock
 
 from mcp_logseq.config import load_exclude_tags
+from mcp_logseq.access import AccessConfig
 from mcp_logseq.tools import (
     _extract_tags,
     _is_page_excluded,
@@ -22,6 +23,14 @@ from mcp_logseq.tools import (
     SearchToolHandler,
     QueryToolHandler,
 )
+
+
+def _exclude_tags_patch(tags):
+    """Patch the cached ACL config with the given exclude tags."""
+    return patch(
+        "mcp_logseq.access.get_access_config",
+        return_value=AccessConfig(exclude_tags=tags),
+    )
 
 
 # =============================================================================
@@ -168,7 +177,7 @@ def test_list_pages_excludes_tagged_pages(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = ListPagesToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"include_journals": True})
 
     text = result[0].text
@@ -187,7 +196,7 @@ def test_list_pages_no_filter_when_exclude_empty(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = ListPagesToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", []):
+    with _exclude_tags_patch([]):
         result = handler.run_tool({})
 
     assert "Private Page" in result[0].text
@@ -205,7 +214,7 @@ def test_list_pages_multiple_excluded_tags(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = ListPagesToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private", "draft"]):
+    with _exclude_tags_patch(["private", "draft"]):
         result = handler.run_tool({})
 
     text = result[0].text
@@ -230,7 +239,7 @@ def test_get_page_content_raises_for_excluded_page(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = GetPageContentToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         with pytest.raises(RuntimeError, match="Access denied"):
             handler.run_tool({"page_name": "Secret Diary"})
 
@@ -246,7 +255,7 @@ def test_get_page_content_allows_non_excluded_page(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = GetPageContentToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"page_name": "Public Notes"})
 
     assert "Some notes content" in result[0].text
@@ -263,7 +272,7 @@ def test_get_page_content_no_block_when_exclude_empty(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = GetPageContentToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", []):
+    with _exclude_tags_patch([]):
         result = handler.run_tool({"page_name": "Private Page"})
 
     assert "private content" in result[0].text
@@ -291,7 +300,7 @@ def test_search_filters_excluded_page_names(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = SearchToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"query": "test"})
 
     text = result[0].text
@@ -313,7 +322,7 @@ def test_search_no_extra_api_call_when_no_exclude_tags(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = SearchToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", []):
+    with _exclude_tags_patch([]):
         handler.run_tool({"query": "test"})
 
     mock_api.list_pages.assert_not_called()
@@ -336,7 +345,7 @@ def test_search_snippets_dropped_when_exclusion_active(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = SearchToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"query": "test"})
 
     assert "some secret snippet" not in result[0].text
@@ -356,7 +365,7 @@ def test_search_snippets_shown_when_no_exclusion(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = SearchToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", []):
+    with _exclude_tags_patch([]):
         result = handler.run_tool({"query": "test"})
 
     assert "a visible snippet" in result[0].text
@@ -378,7 +387,7 @@ def test_query_filters_excluded_page_objects(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = QueryToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"query": "(page-property type x)"})
 
     text = result[0].text
@@ -397,7 +406,7 @@ def test_query_block_objects_pass_through(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = QueryToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+    with _exclude_tags_patch(["private"]):
         result = handler.run_tool({"query": "(page-property type x)"})
 
     assert "A block result" in result[0].text
@@ -413,7 +422,7 @@ def test_query_no_filter_when_exclude_empty(mock_logseq_class):
     mock_logseq_class.return_value = mock_api
 
     handler = QueryToolHandler()
-    with patch("mcp_logseq.tools._exclude_tags", []):
+    with _exclude_tags_patch([]):
         result = handler.run_tool({"query": "(page-property type x)"})
 
     assert "Private Page" in result[0].text

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -133,26 +133,35 @@ def test_no_rules_never_blocks():
     assert _is_namespace_blocked("anything/here", [], []) is False
 
 
+from mcp_logseq.access import AccessConfig
+
+
+def _acl_patch(include=None, exclude=None, tags=None):
+    """Patch the cached ACL config for a test."""
+    return patch(
+        "mcp_logseq.access.get_access_config",
+        return_value=AccessConfig(
+            exclude_tags=tags or [],
+            include_namespaces=include or [],
+            exclude_namespaces=exclude or [],
+        ),
+    )
+
+
 def test_is_page_blocked_by_tag(monkeypatch):
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]), \
-         patch("mcp_logseq.tools._include_namespaces", []), \
-         patch("mcp_logseq.tools._exclude_namespaces", []):
+    with _acl_patch(tags=["private"]):
         page = {"properties": {"tags": ["private"]}}
         assert _is_page_blocked(page, "work/x") is True
 
 
 def test_is_page_blocked_by_namespace(monkeypatch):
-    with patch("mcp_logseq.tools._exclude_tags", []), \
-         patch("mcp_logseq.tools._include_namespaces", []), \
-         patch("mcp_logseq.tools._exclude_namespaces", ["finance"]):
+    with _acl_patch(exclude=["finance"]):
         page = {"properties": {"tags": []}}
         assert _is_page_blocked(page, "finance/q3") is True
 
 
 def test_is_page_blocked_false_when_clear(monkeypatch):
-    with patch("mcp_logseq.tools._exclude_tags", ["private"]), \
-         patch("mcp_logseq.tools._include_namespaces", []), \
-         patch("mcp_logseq.tools._exclude_namespaces", ["finance"]):
+    with _acl_patch(tags=["private"], exclude=["finance"]):
         page = {"properties": {"tags": ["notes"]}}
         assert _is_page_blocked(page, "work/x") is False
 
@@ -170,13 +179,8 @@ from mcp_logseq.tools import (
 
 
 def _ns(include=None, exclude=None):
-    """Patch namespace module config for a test."""
-    return patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=include or [],
-        _exclude_namespaces=exclude or [],
-        _exclude_tags=[],
-    )
+    """Patch namespace ACL config for a test."""
+    return _acl_patch(include=include, exclude=exclude)
 
 
 def test_get_page_content_denies_excluded_namespace():
@@ -303,12 +307,8 @@ def test_get_block_denies_when_page_tag_excluded():
     fake = Mock()
     fake.get_block_page_name.return_value = "work/vault"  # allowed namespace
     fake.get_page_content.return_value = {"page": {"properties": {"tags": ["keys"]}}}
-    with patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=["work"],
-        _exclude_namespaces=[],
-        _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+    with _acl_patch(include=["work"], tags=["keys"]), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
         with pytest.raises(AccessDenied):
             GetBlockToolHandler().run_tool({"block_uuid": "u-tag"})
 
@@ -319,12 +319,8 @@ def test_get_block_allowed_when_page_not_tag_excluded():
     fake.get_block_page_name.return_value = "work/vault"
     fake.get_page_content.return_value = {"page": {"properties": {"tags": ["notes"]}}}
     fake.get_block.return_value = {"content": "visible block content", "children": []}
-    with patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=["work"],
-        _exclude_namespaces=[],
-        _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+    with _acl_patch(include=["work"], tags=["keys"]), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
         out = GetBlockToolHandler().run_tool({"block_uuid": "u-ok"})[0].text
         assert "visible block content" in out
 
@@ -761,12 +757,8 @@ def test_db_search_filters_block_from_tag_excluded_page_text():
         "uuid-vault": "vault",
         "uuid-notes": "notes",
     }
-    with patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=[],
-        _exclude_namespaces=[],
-        _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._get_db_mode", return_value=True), \
+    with _acl_patch(tags=["keys"]), \
+            patch("mcp_logseq.tools._get_db_mode", return_value=True), \
             patch("mcp_logseq.tools._make_api", return_value=fake):
         out = SearchToolHandler().run_tool({"query": "note"})[0].text
         assert "AKIA-leak" not in out
@@ -870,12 +862,8 @@ def test_query_filters_block_from_tag_excluded_page():
         return {"page": {"properties": {}}}
 
     fake.get_page_content.side_effect = _content
-    with patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=[],
-        _exclude_namespaces=[],
-        _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+    with _acl_patch(tags=["keys"]), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
         out = QueryToolHandler().run_tool({"query": "(page-tags)"})[0].text
         assert "AKIA-leak" not in out
         assert "public note" in out
@@ -902,12 +890,8 @@ def test_query_tag_fetch_deduped_per_owning_page():
         {"content": "beta", "page": {"originalName": "notes"}},
     ]
     fake.get_page_content.return_value = {"page": {"properties": {}}}
-    with patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=[],
-        _exclude_namespaces=[],
-        _exclude_tags=["keys"],
-    ), patch("mcp_logseq.tools._make_api", return_value=fake):
+    with _acl_patch(tags=["keys"]), \
+            patch("mcp_logseq.tools._make_api", return_value=fake):
         out = QueryToolHandler().run_tool({"query": "(task TODO)"})[0].text
         assert "alpha" in out
         assert "beta" in out
@@ -943,12 +927,7 @@ def test_vector_results_filtered_by_tags():
 
 def _priv():
     """Patch config so the 'Private' namespace is excluded."""
-    return patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=[],
-        _exclude_namespaces=["Private"],
-        _exclude_tags=[],
-    )
+    return _acl_patch(exclude=["Private"])
 
 
 def test_regression_create_page_denies_private():
@@ -1097,12 +1076,7 @@ def _tagged_page_api(tag="keys"):
 
 
 def _tags_excluded(tag="keys"):
-    return patch.multiple(
-        "mcp_logseq.tools",
-        _include_namespaces=[],
-        _exclude_namespaces=[],
-        _exclude_tags=[tag],
-    )
+    return _acl_patch(tags=[tag])
 
 
 def test_update_page_denies_tag_excluded_existing_page():
@@ -1188,7 +1162,6 @@ def test_tag_on_write_fails_closed_when_page_fetch_raises():
 def test_vector_search_drops_tag_excluded_chunk(monkeypatch):
     """A #keys chunk in the shared DB must not surface when 'keys' is excluded."""
     pytest.importorskip("mcp_logseq.vector.index")
-    import mcp_logseq.vector.index as vindex
     from mcp_logseq.vector.index import VectorSearchToolHandler
     from mcp_logseq.vector.types import SearchResult
 
@@ -1211,9 +1184,7 @@ def test_vector_search_drops_tag_excluded_chunk(monkeypatch):
     meta.dimensions = 3
 
     with (
-        patch.object(vindex, "_exclude_tags", ["keys"]),
-        patch.object(vindex, "_include_namespaces", []),
-        patch.object(vindex, "_exclude_namespaces", []),
+        _acl_patch(tags=["keys"]),
         patch("mcp_logseq.vector.index.StateManager") as mock_sm,
         patch("mcp_logseq.vector.index.check_staleness") as mock_stale,
         patch("mcp_logseq.vector.index.create_embedder") as mock_emb,

--- a/tests/unit/test_tool_handlers.py
+++ b/tests/unit/test_tool_handlers.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from unittest.mock import patch, Mock
 from mcp.types import TextContent
+from mcp_logseq.access import AccessConfig
 import mcp_logseq.tools as tools
 from mcp_logseq.tools import (
     CreatePageToolHandler,
@@ -1017,7 +1018,7 @@ class TestSearchToolHandler:
         mock_logseq_class.return_value = mock_api
 
         handler = SearchToolHandler()
-        with patch("mcp_logseq.tools._exclude_tags", ["private"]):
+        with patch("mcp_logseq.access.get_access_config", return_value=AccessConfig(exclude_tags=["private"])):
             result = handler.run_tool({"query": "secret", "format": "json"})
 
         data = json.loads(result[0].text)


### PR DESCRIPTION
## What

Follow-up to #84 (A1). Addresses two more architecture review items:

- **A6**: `vector/index.py` was importing four underscore-prefixed privates (`_is_namespace_blocked`, `_include_namespaces`, `_exclude_namespaces`, `_exclude_tags`) straight from `tools.py`. The ACL layer now lives in a dedicated `access.py` module that both `tools.py` and `vector/index.py` import.
- **A7**: the config file was opened and parsed once per ACL list. `read_config_file()` is now the single choke point for config-file IO, and `load_access_config()` resolves all three lists from one parse.

## Changes

- New `access.py`: frozen `AccessConfig` dataclass, `load_access_config()`, cached `get_access_config()` (same lazy pattern as `settings.py`), `AccessDenied`, and all ACL predicates and enforcement helpers moved over from `tools.py`.
- `config.py`: shared `read_config_file()` + `csv_config_value()`; the per-list loaders stay as thin wrappers so their behavior (env var > config file priority) is unchanged.
- `tools.py`: no more import-time config reads. This removes the last import-time side effects; the package now imports with no environment variables set at all. Handler call sites are unchanged via import aliases.
- `vector/index.py`: reads ACL state through `access.get_access_config()` and `namespace.is_namespace_blocked` instead of `tools.py` internals.
- `server.py`: merges vector `exclude_tags` from `get_access_config()`.
- Tests: ACL patch sites now patch `mcp_logseq.access.get_access_config` with an `AccessConfig` instead of poking `tools.py` module globals; new `tests/unit/test_access.py` covers lazy loading, caching, env/file priority, and the single-parse guarantee.

## Testing

614 tests pass (was 603; 11 new access tests). No behavior change intended: enforcement semantics, fail-closed rules, and log messages are preserved.