### PR TITLE
refactor: declarative pre-dispatch access control (A4)

### DIFF
--- a/src/mcp_logseq/access.py
+++ b/src/mcp_logseq/access.py
@@ -175,3 +175,79 @@ def enforce_block_tag_access(api, block_uuid: str) -> None:
             f"Access denied: cannot verify the owning page of block '{block_uuid}'."
         )
     enforce_page_tag_access(api, page_name)
+
+
+# ---------------------------------------------------------------------------
+# Declarative access policies (architecture review A4)
+#
+# A handler no longer hand-wires ``enforce_*`` calls at the top of its
+# ``run_tool``; instead it *declares* an ``access_policy`` list of these
+# objects, and ``ToolHandler.run_tool`` runs them at a single choke point
+# before dispatch. Each policy is a thin, side-effect-free wrapper over the
+# ``enforce_*`` functions above — the enforcement logic is unchanged; only the
+# wiring becomes declarative and impossible for a new handler to forget.
+#
+# Every policy names the ``run_tool`` argument that carries the resource
+# identifier (a page name or a block UUID) and is a no-op when that argument
+# is absent or empty — argument-required validation remains the handler's job
+# and still runs (and raises) inside ``_run``.
+# ---------------------------------------------------------------------------
+
+
+class AccessPolicy:
+    """A declarative pre-dispatch access check.
+
+    ``enforce`` runs before the handler body and raises ``AccessDenied`` (or
+    propagates a fetch error, fail-closed) when the resource is restricted.
+    """
+
+    def enforce(self, api, args: dict) -> None:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class NamespaceName(AccessPolicy):
+    """Name-based namespace gate on the page name in ``args[arg]``."""
+
+    arg: str
+
+    def enforce(self, api, args: dict) -> None:
+        name = args.get(self.arg)
+        if name:
+            enforce_namespace_access(name)
+
+
+@dataclass(frozen=True)
+class PageTag(AccessPolicy):
+    """Tag-exclusion gate on the EXISTING page named by ``args[arg]``."""
+
+    arg: str
+
+    def enforce(self, api, args: dict) -> None:
+        name = args.get(self.arg)
+        if name:
+            enforce_page_tag_access(api, name)
+
+
+@dataclass(frozen=True)
+class BlockNamespace(AccessPolicy):
+    """Namespace gate on the owning page of the block in ``args[arg]``."""
+
+    arg: str
+
+    def enforce(self, api, args: dict) -> None:
+        uuid = args.get(self.arg)
+        if uuid:
+            enforce_block_namespace_access(api, uuid)
+
+
+@dataclass(frozen=True)
+class BlockTag(AccessPolicy):
+    """Tag-exclusion gate on the owning page of the block in ``args[arg]``."""
+
+    arg: str
+
+    def enforce(self, api, args: dict) -> None:
+        uuid = args.get(self.arg)
+        if uuid:
+            enforce_block_tag_access(api, uuid)

--- a/src/mcp_logseq/tools/base.py
+++ b/src/mcp_logseq/tools/base.py
@@ -64,6 +64,14 @@ def _resolve_block_refs(content: str, uuid_map: dict[str, str]) -> str:
 
 
 class ToolHandler:
+    #: Declarative pre-dispatch access checks (architecture review A4). Each
+    #: handler lists the ``access.AccessPolicy`` objects that gate it; the base
+    #: ``run_tool`` runs them at a single choke point before ``_run``, so a new
+    #: handler cannot silently ship without enforcement. An empty list means the
+    #: handler has no pre-dispatch gate (it either needs none or filters results
+    #: itself via ``access.is_page_blocked``).
+    access_policy: "list" = []
+
     def __init__(self, tool_name: str):
         self.name = tool_name
 
@@ -71,4 +79,24 @@ class ToolHandler:
         raise NotImplementedError()
 
     def run_tool(self, args: dict) -> list[TextContent]:
+        """Enforce the declared access policy, then dispatch to ``_run``.
+
+        This is the single choke point for pre-dispatch access control: the API
+        client is built once, every declared policy runs against it (raising
+        ``AccessDenied`` fail-loud, uniformly, before any handler logic), and the
+        same client is handed to ``_run``. Handlers implement ``_run`` and never
+        wire enforcement by hand.
+
+        ``_make_api`` is looked up via the package namespace (``_t._make_api``)
+        so ``patch("mcp_logseq.tools._make_api")`` in the test suite intercepts
+        it — the same indirection the submodule handlers use.
+        """
+        import mcp_logseq.tools as _t
+
+        api = _t._make_api()
+        for policy in self.access_policy:
+            policy.enforce(api, args)
+        return self._run(api, args)
+
+    def _run(self, api, args: dict) -> list[TextContent]:
         raise NotImplementedError()

--- a/src/mcp_logseq/tools/blocks.py
+++ b/src/mcp_logseq/tools/blocks.py
@@ -5,17 +5,18 @@ import json
 from mcp.types import Tool, TextContent
 
 import mcp_logseq.tools as _t
-from ..access import (
-    AccessDenied,
-    enforce_block_namespace_access as _enforce_block_namespace_access,
-    enforce_block_tag_access as _enforce_block_tag_access,
-)
+from .. import access
 from .base import ToolHandler, logger
 # GetBlock reuses GetPageContent's block-tree formatter.
 from .pages import GetPageContentToolHandler
 
 
 class DeleteBlockToolHandler(ToolHandler):
+    access_policy = [
+        access.BlockNamespace("block_uuid"),
+        access.BlockTag("block_uuid"),
+    ]
+
     def __init__(self):
         super().__init__("delete_block")
 
@@ -35,24 +36,19 @@ class DeleteBlockToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "block_uuid" not in args:
             raise RuntimeError("block_uuid argument required")
 
         block_uuid = args["block_uuid"]
 
         try:
-            api = _t._make_api()
-            _enforce_block_namespace_access(api, block_uuid)
-            _enforce_block_tag_access(api, block_uuid)
             api.delete_block(block_uuid)
 
             return [TextContent(
                 type="text",
                 text=f"✅ Successfully deleted block '{block_uuid}'"
             )]
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(
                 type="text",
@@ -67,6 +63,11 @@ class DeleteBlockToolHandler(ToolHandler):
 
 
 class UpdateBlockToolHandler(ToolHandler):
+    access_policy = [
+        access.BlockNamespace("block_uuid"),
+        access.BlockTag("block_uuid"),
+    ]
+
     def __init__(self):
         super().__init__("update_block")
 
@@ -90,7 +91,7 @@ class UpdateBlockToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "block_uuid" not in args or "content" not in args:
             raise RuntimeError("block_uuid and content arguments required")
 
@@ -98,17 +99,12 @@ class UpdateBlockToolHandler(ToolHandler):
         content = args["content"]
 
         try:
-            api = _t._make_api()
-            _enforce_block_namespace_access(api, block_uuid)
-            _enforce_block_tag_access(api, block_uuid)
             api.update_block(block_uuid, content)
 
             return [TextContent(
                 type="text",
                 text=f"✅ Successfully updated block '{block_uuid}'"
             )]
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(
                 type="text",
@@ -124,6 +120,11 @@ class UpdateBlockToolHandler(ToolHandler):
 
 class GetBlockToolHandler(ToolHandler):
     """Retrieve a single block by UUID, including its content, properties, and children."""
+
+    access_policy = [
+        access.BlockNamespace("block_uuid"),
+        access.BlockTag("block_uuid"),
+    ]
 
     def __init__(self):
         super().__init__("get_block")
@@ -155,7 +156,7 @@ class GetBlockToolHandler(ToolHandler):
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "block_uuid" not in args:
             raise RuntimeError("block_uuid argument required")
 
@@ -164,9 +165,6 @@ class GetBlockToolHandler(ToolHandler):
         output_format = args.get("format", "text")
 
         try:
-            api = _t._make_api()
-            _enforce_block_namespace_access(api, block_uuid)
-            _enforce_block_tag_access(api, block_uuid)
             result = api.get_block(block_uuid, include_children=include_children)
 
             if output_format == "json":
@@ -197,8 +195,6 @@ class GetBlockToolHandler(ToolHandler):
 
             return [TextContent(type="text", text="\n".join(content_parts))]
 
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(type="text", text=f"Error: {str(e)}")]
         except Exception as e:
@@ -210,6 +206,11 @@ class GetBlockToolHandler(ToolHandler):
 
 
 class InsertNestedBlockToolHandler(ToolHandler):
+    access_policy = [
+        access.BlockNamespace("parent_block_uuid"),
+        access.BlockTag("parent_block_uuid"),
+    ]
+
     def __init__(self):
         super().__init__("insert_nested_block")
 
@@ -243,7 +244,7 @@ class InsertNestedBlockToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Insert a nested block under an existing block."""
         if "parent_block_uuid" not in args or "content" not in args:
             raise RuntimeError("parent_block_uuid and content arguments required")
@@ -254,9 +255,6 @@ class InsertNestedBlockToolHandler(ToolHandler):
         sibling = args.get("sibling", False)
 
         try:
-            api = _t._make_api()
-            _enforce_block_namespace_access(api, parent_uuid)
-            _enforce_block_tag_access(api, parent_uuid)
             result = api.insert_block_as_child(
                 parent_block_uuid=parent_uuid,
                 content=content,
@@ -284,8 +282,6 @@ class InsertNestedBlockToolHandler(ToolHandler):
                 text=success_msg
             )]
 
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(
                 type="text",
@@ -300,6 +296,11 @@ class InsertNestedBlockToolHandler(ToolHandler):
 
 
 class SetBlockPropertiesToolHandler(ToolHandler):
+    access_policy = [
+        access.BlockNamespace("block_uuid"),
+        access.BlockTag("block_uuid"),
+    ]
+
     def __init__(self):
         super().__init__("set_block_properties")
 
@@ -324,7 +325,7 @@ class SetBlockPropertiesToolHandler(ToolHandler):
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Set DB-mode properties on a block."""
         if not _t._get_db_mode():
             return [TextContent(
@@ -339,9 +340,6 @@ class SetBlockPropertiesToolHandler(ToolHandler):
         properties = args["properties"]
 
         try:
-            api = _t._make_api()
-            _enforce_block_namespace_access(api, block_uuid)
-            _enforce_block_tag_access(api, block_uuid)
             results = []
 
             for prop_name, value in properties.items():
@@ -359,8 +357,6 @@ class SetBlockPropertiesToolHandler(ToolHandler):
                 text=f"Set properties on block {block_uuid}:\n" + "\n".join(results),
             )]
 
-        except AccessDenied:
-            raise
         except Exception as e:
             logger.error(f"Failed to set block properties: {str(e)}")
             return [TextContent(

--- a/src/mcp_logseq/tools/namespace.py
+++ b/src/mcp_logseq/tools/namespace.py
@@ -2,15 +2,17 @@
 
 from mcp.types import Tool, TextContent
 
-import mcp_logseq.tools as _t
+from .. import access
 from ..access import (
     is_page_blocked as _is_page_blocked,
-    enforce_namespace_access as _enforce_namespace_access,
 )
 from .base import ToolHandler, logger
 
 
 class GetPagesFromNamespaceToolHandler(ToolHandler):
+    # Gate the queried namespace by name; results are filtered in _run.
+    access_policy = [access.NamespaceName("namespace")]
+
     def __init__(self):
         super().__init__("get_pages_from_namespace")
 
@@ -30,14 +32,11 @@ class GetPagesFromNamespaceToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "namespace" not in args:
             raise RuntimeError("namespace argument required")
 
-        _enforce_namespace_access(args["namespace"])
-
         try:
-            api = _t._make_api()
             result = api.get_pages_from_namespace(args["namespace"])
 
             # Security: silently drop pages blocked by tag OR namespace, e.g. an
@@ -74,6 +73,9 @@ class GetPagesFromNamespaceToolHandler(ToolHandler):
 
 
 class GetPagesTreeFromNamespaceToolHandler(ToolHandler):
+    # Gate the root namespace by name; the tree is pruned in _run.
+    access_policy = [access.NamespaceName("namespace")]
+
     def __init__(self):
         super().__init__("get_pages_tree_from_namespace")
 
@@ -93,14 +95,11 @@ class GetPagesTreeFromNamespaceToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "namespace" not in args:
             raise RuntimeError("namespace argument required")
 
-        _enforce_namespace_access(args["namespace"])
-
         try:
-            api = _t._make_api()
             result = api.get_pages_tree_from_namespace(args["namespace"])
 
             # Security: silently prune nodes blocked by tag OR namespace, e.g. an

--- a/src/mcp_logseq/tools/pages.py
+++ b/src/mcp_logseq/tools/pages.py
@@ -11,8 +11,6 @@ from .. import access
 from ..access import (
     AccessDenied,
     is_page_blocked as _is_page_blocked,
-    enforce_namespace_access as _enforce_namespace_access,
-    enforce_page_tag_access as _enforce_page_tag_access,
 )
 from .base import (
     ToolHandler,
@@ -34,6 +32,8 @@ class CreatePageToolHandler(ToolHandler):
     - Blockquotes (>)
     - YAML frontmatter for page properties
     """
+
+    access_policy = [access.NamespaceName("title")]
 
     def __init__(self):
         super().__init__("create_page")
@@ -86,7 +86,7 @@ Introduction paragraph.
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "title" not in args:
             raise RuntimeError("title argument required")
 
@@ -94,11 +94,7 @@ Introduction paragraph.
         content = args.get("content", "")
         explicit_properties = args.get("properties", {})
 
-        _enforce_namespace_access(title)
-
         try:
-            api = _t._make_api()
-
             # Refuse to create a duplicate: Logseq auto-numbers pages with an
             # existing name ("Page(1)", "Page 2"), which silently fragments
             # content when a timed-out create_page is retried (issue #58).
@@ -141,6 +137,9 @@ Introduction paragraph.
 
 
 class ListPagesToolHandler(ToolHandler):
+    # No pre-dispatch gate: results are filtered per-page via is_page_blocked.
+    access_policy = []
+
     def __init__(self):
         super().__init__("list_pages")
 
@@ -161,11 +160,10 @@ class ListPagesToolHandler(ToolHandler):
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         include_journals = args.get("include_journals", False)
 
         try:
-            api = _t._make_api()
             result = api.list_pages()
 
             # Format pages for display
@@ -213,6 +211,10 @@ class ListPagesToolHandler(ToolHandler):
 
 
 class GetPageContentToolHandler(ToolHandler):
+    # Namespace is name-checkable up front; the tag/namespace check on the
+    # fetched page stays inline in _run (it needs the page body).
+    access_policy = [access.NamespaceName("page_name")]
+
     def __init__(self):
         super().__init__("get_page_content")
 
@@ -316,18 +318,14 @@ class GetPageContentToolHandler(ToolHandler):
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Get and format LogSeq page content."""
         logger.info(f"Getting page content with args: {args}")
 
         if "page_name" not in args:
             raise RuntimeError("page_name argument required")
 
-        # Pre-flight: namespace check is name-based, no API call needed
-        _enforce_namespace_access(args["page_name"])
-
         try:
-            api = _t._make_api()
             result = api.get_page_content(args["page_name"])
 
             if not result:
@@ -409,6 +407,11 @@ class GetPageContentToolHandler(ToolHandler):
 
 
 class DeletePageToolHandler(ToolHandler):
+    access_policy = [
+        access.NamespaceName("page_name"),
+        access.PageTag("page_name"),
+    ]
+
     def __init__(self):
         super().__init__("delete_page")
 
@@ -428,15 +431,11 @@ class DeletePageToolHandler(ToolHandler):
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "page_name" not in args:
             raise RuntimeError("page_name argument required")
 
-        _enforce_namespace_access(args["page_name"])
-
         try:
-            api = _t._make_api()
-            _enforce_page_tag_access(api, args["page_name"])
             result = api.delete_page(args["page_name"])
 
             # Build detailed success message
@@ -455,8 +454,6 @@ class DeletePageToolHandler(ToolHandler):
             )
 
             return [TextContent(type="text", text=success_msg)]
-        except AccessDenied:
-            raise
         except ValueError as e:
             # Handle validation errors (page not found) gracefully
             return [TextContent(type="text", text=f"❌ Error: {str(e)}")]
@@ -478,6 +475,11 @@ class UpdatePageToolHandler(ToolHandler):
     - append: Add new blocks after existing content (default)
     - replace: Clear existing content and add new blocks
     """
+
+    access_policy = [
+        access.NamespaceName("page_name"),
+        access.PageTag("page_name"),
+    ]
 
     def __init__(self):
         super().__init__("update_page")
@@ -520,7 +522,7 @@ YAML frontmatter in content will be merged with explicit properties.""",
             },
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "page_name" not in args:
             raise RuntimeError("page_name argument required")
 
@@ -528,8 +530,6 @@ YAML frontmatter in content will be merged with explicit properties.""",
         content = args.get("content", "")
         mode = args.get("mode", "append")
         explicit_properties = args.get("properties", {})
-
-        _enforce_namespace_access(page_name)
 
         # Validate that at least one update is provided
         if not content and not explicit_properties:
@@ -541,9 +541,6 @@ YAML frontmatter in content will be merged with explicit properties.""",
             ]
 
         try:
-            api = _t._make_api()
-            _enforce_page_tag_access(api, page_name)
-
             # Parse the content
             parsed = (
                 parser.parse_content(content) if content else parser.ParsedContent()
@@ -581,8 +578,6 @@ YAML frontmatter in content will be merged with explicit properties.""",
             msg_parts.append(f"Mode: {mode}")
 
             return [TextContent(type="text", text="\n".join(msg_parts))]
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(type="text", text=f"Error: {str(e)}")]
         except Exception as e:
@@ -596,6 +591,9 @@ YAML frontmatter in content will be merged with explicit properties.""",
 
 class FindPagesByPropertyToolHandler(ToolHandler):
     """Find pages by property name and optional value."""
+
+    # No pre-dispatch gate: results are filtered via is_page_blocked below.
+    access_policy = []
 
     def __init__(self):
         super().__init__("find_pages_by_property")
@@ -636,7 +634,7 @@ class FindPagesByPropertyToolHandler(ToolHandler):
             raise ValueError(f"Invalid property name '{name}': only alphanumeric, hyphens, and underscores allowed")
         return name
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Find pages by property and format results."""
         if "property_name" not in args:
             raise RuntimeError("property_name argument required")
@@ -656,7 +654,6 @@ class FindPagesByPropertyToolHandler(ToolHandler):
             query = f'(page-property {property_name})'
 
         try:
-            api = _t._make_api()
             result = api.query_dsl(query)
 
             if not result:
@@ -721,6 +718,14 @@ class FindPagesByPropertyToolHandler(ToolHandler):
 
 
 class RenamePageToolHandler(ToolHandler):
+    # Both names are namespace-gated; the tag guard applies to the existing
+    # SOURCE page only (the target is a not-yet-existing page with no tags).
+    access_policy = [
+        access.NamespaceName("old_name"),
+        access.NamespaceName("new_name"),
+        access.PageTag("old_name"),
+    ]
+
     def __init__(self):
         super().__init__("rename_page")
 
@@ -744,21 +749,14 @@ class RenamePageToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "old_name" not in args or "new_name" not in args:
             raise RuntimeError("old_name and new_name arguments required")
 
         old_name = args["old_name"]
         new_name = args["new_name"]
 
-        _enforce_namespace_access(old_name)
-        _enforce_namespace_access(new_name)
-
         try:
-            api = _t._make_api()
-            # Tag-on-write: guard the SOURCE page (existing). The target name is
-            # a not-yet-existing page, so it has no prior tags to check.
-            _enforce_page_tag_access(api, old_name)
             api.rename_page(old_name, new_name)
 
             return [TextContent(
@@ -766,8 +764,6 @@ class RenamePageToolHandler(ToolHandler):
                 text=f"Successfully renamed page '{old_name}' to '{new_name}'\n"
                      f"All references in the graph have been updated."
             )]
-        except AccessDenied:
-            raise
         except ValueError as e:
             return [TextContent(
                 type="text",
@@ -782,6 +778,9 @@ class RenamePageToolHandler(ToolHandler):
 
 
 class GetPageBacklinksToolHandler(ToolHandler):
+    # Gate the queried page by name; referring pages are filtered in _run.
+    access_policy = [access.NamespaceName("page_name")]
+
     def __init__(self):
         super().__init__("get_page_backlinks")
 
@@ -806,17 +805,14 @@ class GetPageBacklinksToolHandler(ToolHandler):
             }
         )
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         if "page_name" not in args:
             raise RuntimeError("page_name argument required")
 
         page_name = args["page_name"]
         include_content = args.get("include_content", True)
 
-        _enforce_namespace_access(page_name)
-
         try:
-            api = _t._make_api()
             result = api.get_page_linked_references(page_name)
 
             if not result:

--- a/src/mcp_logseq/tools/search.py
+++ b/src/mcp_logseq/tools/search.py
@@ -15,6 +15,10 @@ from .base import ToolHandler, logger, _UUID_REF_PATTERN
 
 
 class SearchToolHandler(ToolHandler):
+    # No pre-dispatch gate: results are filtered via a bespoke fail-closed
+    # exclusion set (_build_excluded_page_names) inside _run.
+    access_policy = []
+
     def __init__(self):
         super().__init__("search")
 
@@ -334,7 +338,7 @@ class SearchToolHandler(ToolHandler):
 
         return out
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Execute search and format results."""
         logger.info(f"Searching with args: {args}")
 
@@ -351,7 +355,6 @@ class SearchToolHandler(ToolHandler):
             # Prepare search options
             search_options = {"limit": limit}
 
-            api = _t._make_api()
             result = api.search_content(query, search_options)
 
             if not result:
@@ -400,6 +403,10 @@ class SearchToolHandler(ToolHandler):
 
 class QueryToolHandler(ToolHandler):
     """Execute Logseq DSL queries to search pages and blocks."""
+
+    # No pre-dispatch gate: page and block results are filtered via a bespoke
+    # fail-closed tag/namespace check (_block_blocked / _is_page_blocked) in _run.
+    access_policy = []
 
     def __init__(self):
         super().__init__("query")
@@ -539,7 +546,7 @@ class QueryToolHandler(ToolHandler):
             name = item.get("originalName") or item.get("name") or str(item)[:50]
             return f"{index}. {name}"
 
-    def run_tool(self, args: dict) -> list[TextContent]:
+    def _run(self, api, args: dict) -> list[TextContent]:
         """Execute DSL query and format results."""
         if "query" not in args:
             raise RuntimeError("query argument required")
@@ -549,7 +556,6 @@ class QueryToolHandler(ToolHandler):
         result_type = args.get("result_type", "all")
 
         try:
-            api = _t._make_api()
             result = api.query_dsl(query)
 
             if not result:

--- a/tests/unit/test_access_policy_coverage.py
+++ b/tests/unit/test_access_policy_coverage.py
@@ -1,0 +1,133 @@
+"""Structural guarantee for declarative access control (architecture review A4).
+
+Enforcement is no longer hand-wired at the top of each handler's ``run_tool``;
+handlers declare an ``access_policy`` list that the base ``ToolHandler.run_tool``
+runs at a single choke point before dispatch. These tests pin that contract so a
+future handler cannot silently ship without the right gate:
+
+- every mutating/content handler declares the expected policy *types* on the
+  right argument, and
+- the base choke point actually enforces the declared policy before ``_run``.
+
+If you add or rename a handler, update ``EXPECTED_POLICIES`` deliberately — that
+edit is the audit trail for a security-boundary change.
+"""
+
+import pytest
+
+from mcp_logseq import access
+from mcp_logseq import tools
+
+
+# Expected declarative policy per handler: {class: {(PolicyType, arg), ...}}.
+# Order does not matter; the SET of (type, arg) pairs is the contract.
+EXPECTED_POLICIES = {
+    # Page handlers -----------------------------------------------------------
+    tools.CreatePageToolHandler: {(access.NamespaceName, "title")},
+    tools.GetPageContentToolHandler: {(access.NamespaceName, "page_name")},
+    tools.DeletePageToolHandler: {
+        (access.NamespaceName, "page_name"),
+        (access.PageTag, "page_name"),
+    },
+    tools.UpdatePageToolHandler: {
+        (access.NamespaceName, "page_name"),
+        (access.PageTag, "page_name"),
+    },
+    tools.RenamePageToolHandler: {
+        (access.NamespaceName, "old_name"),
+        (access.NamespaceName, "new_name"),
+        (access.PageTag, "old_name"),
+    },
+    tools.GetPageBacklinksToolHandler: {(access.NamespaceName, "page_name")},
+    # Block handlers (identical namespace + tag pair on the uuid argument) -----
+    tools.DeleteBlockToolHandler: {
+        (access.BlockNamespace, "block_uuid"),
+        (access.BlockTag, "block_uuid"),
+    },
+    tools.UpdateBlockToolHandler: {
+        (access.BlockNamespace, "block_uuid"),
+        (access.BlockTag, "block_uuid"),
+    },
+    tools.GetBlockToolHandler: {
+        (access.BlockNamespace, "block_uuid"),
+        (access.BlockTag, "block_uuid"),
+    },
+    tools.InsertNestedBlockToolHandler: {
+        (access.BlockNamespace, "parent_block_uuid"),
+        (access.BlockTag, "parent_block_uuid"),
+    },
+    tools.SetBlockPropertiesToolHandler: {
+        (access.BlockNamespace, "block_uuid"),
+        (access.BlockTag, "block_uuid"),
+    },
+    # Namespace-tree handlers (name-gated; results filtered in _run) -----------
+    tools.GetPagesFromNamespaceToolHandler: {(access.NamespaceName, "namespace")},
+    tools.GetPagesTreeFromNamespaceToolHandler: {(access.NamespaceName, "namespace")},
+    # Result-filtering handlers: no pre-dispatch gate by design (they drop
+    # restricted rows inside _run via is_page_blocked / bespoke filters).
+    tools.ListPagesToolHandler: set(),
+    tools.FindPagesByPropertyToolHandler: set(),
+    tools.SearchToolHandler: set(),
+    tools.QueryToolHandler: set(),
+}
+
+
+def _policy_pairs(handler_cls) -> set:
+    return {(type(p), p.arg) for p in handler_cls.access_policy}
+
+
+@pytest.mark.parametrize("handler_cls, expected", EXPECTED_POLICIES.items())
+def test_handler_declares_expected_policy(handler_cls, expected):
+    assert _policy_pairs(handler_cls) == expected
+
+
+def test_every_core_handler_is_covered():
+    """No core handler may escape the coverage table above.
+
+    Every ``ToolHandler`` subclass re-exported from ``mcp_logseq.tools`` must
+    appear in ``EXPECTED_POLICIES``. A new handler that isn't listed fails here,
+    forcing a deliberate decision about its access policy.
+    """
+    exported = {
+        getattr(tools, name)
+        for name in tools.__all__
+        if isinstance(getattr(tools, name), type)
+        and issubclass(getattr(tools, name), tools.ToolHandler)
+        and getattr(tools, name) is not tools.ToolHandler
+    }
+    missing = exported - set(EXPECTED_POLICIES)
+    assert not missing, (
+        f"Handlers missing from EXPECTED_POLICIES (declare their access "
+        f"policy and add them to the table): {sorted(c.__name__ for c in missing)}"
+    )
+
+
+def test_base_choke_point_enforces_before_dispatch():
+    """The declared policy must run before ``_run`` — proving the gate is not
+    merely declared but actually executed by the base ``run_tool``."""
+
+    calls = []
+
+    class Boom(access.AccessPolicy):
+        def enforce(self, api, args):
+            calls.append("enforced")
+            raise access.AccessDenied("blocked")
+
+    class Probe(tools.ToolHandler):
+        access_policy = [Boom()]
+
+        def __init__(self):
+            super().__init__("probe")
+
+        def _run(self, api, args):
+            calls.append("ran")
+            return []
+
+    from unittest.mock import patch, Mock
+
+    with patch("mcp_logseq.tools._make_api", return_value=Mock()):
+        with pytest.raises(access.AccessDenied):
+            Probe().run_tool({})
+
+    # Enforcement happened; _run never did.
+    assert calls == ["enforced"]

--- a/tests/unit/test_namespace_access.py
+++ b/tests/unit/test_namespace_access.py
@@ -1145,18 +1145,22 @@ def test_rename_page_denies_tag_excluded_source_page():
 
 def test_tag_on_write_fails_closed_when_page_fetch_raises():
     """With exclude tags configured, a page-fetch error must abort the write
-    rather than silently proceeding (no fail-open). The error propagates and the
-    write API is never called."""
+    rather than silently proceeding (no fail-open). The write API is never called.
+
+    Since A4 the tag guard runs as a declarative access policy at the base
+    ``run_tool`` choke point, before the handler body. A fetch error during that
+    check therefore propagates as an exception (fail-closed) instead of being
+    caught by the handler and reported as a soft message — the write still never
+    happens, which is the security invariant this test protects."""
     fake = Mock()
     fake.get_page_content.side_effect = RuntimeError("API down")
     with _tags_excluded(), patch("mcp_logseq.tools._make_api", return_value=fake):
-        out = UpdatePageToolHandler().run_tool(
-            {"page_name": "work/secrets", "content": "c"}
-        )
-        # The write did NOT succeed: update_page_with_blocks never ran, and the
-        # handler reported failure rather than success.
+        with pytest.raises(RuntimeError, match="API down"):
+            UpdatePageToolHandler().run_tool(
+                {"page_name": "work/secrets", "content": "c"}
+            )
+        # The write did NOT succeed: update_page_with_blocks never ran.
         fake.update_page_with_blocks.assert_not_called()
-        assert "Successfully updated" not in out[0].text
 
 
 def test_vector_search_drops_tag_excluded_chunk(monkeypatch):


### PR DESCRIPTION
Implements A4 from the architecture review. ACL enforcement used to be re-implemented by hand at the top of every handler's `run_tool`, so a new handler that forgot the right `enforce_*` call would silently leak restricted content with nothing structural to catch it.

Now handlers *declare* an `access_policy` and the base `ToolHandler.run_tool` runs it at a single choke point before dispatching to `_run(api, args)`. The `enforce_*` logic itself is unchanged; only the wiring becomes declarative. A new coverage test pins each handler's policy and proves the base enforces before the handler body runs, so a future handler can't ship without a deliberate policy decision.

### What changed
- `access.py`: new `AccessPolicy` plus `NamespaceName` / `PageTag` / `BlockNamespace` / `BlockTag`, thin side-effect-free wrappers over the existing `enforce_*` functions.
- `tools/base.py`: `run_tool` is now a template method (build API client once, run the declared policy, dispatch to `_run`). Handlers implement `_run` and no longer wire enforcement or build the client by hand.
- All 17 core handlers migrated; hand-wired `enforce_*` calls and now-dead `except AccessDenied: raise` guards removed.
- New `tests/unit/test_access_policy_coverage.py` pins the per-handler policy contract and the choke-point behavior.

### Behavior change (security invariant preserved)
Enforcement-time errors now surface uniformly from the choke point rather than being swallowed into a per-handler failure string. A fetch error during a write's tag check still aborts the write (fail-closed); it raises instead of returning a soft message. `test_tag_on_write_fails_closed_when_page_fetch_raises` updated to assert the invariant via the exception path.

### Out of scope (unchanged)
Result-filtering handlers (`list_pages`, `search`, `query`, `find_pages_by_property`) and the vector tools already funnel through `access.is_page_blocked` or their own bespoke fail-closed filters.

Tests: 620 passed, 2 skipped.